### PR TITLE
CI 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality:
+    name: Quality Checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "oxlint --fix",
+    "lint": "oxlint --fix --max-warnings 0",
     "format": "oxfmt",
     "typecheck": "tsc --noEmit",
     "prisma": "prisma",


### PR DESCRIPTION
## Summary
- PR 및 main 브랜치 push에서 실행되는 GitHub Actions CI 워크플로 추가
- `pnpm lint`, `pnpm typecheck`, `pnpm test` 실행
- `pnpm lint`가 경고 발생 시 실패하도록 `--max-warnings 0` 적용

## Tests
- `pnpm format`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

Closes #80