### PR TITLE
ActivityPub 수신 로그/디버깅 도구 추가

### DIFF
--- a/src/app/dashboard/activitypub-inbox/page.tsx
+++ b/src/app/dashboard/activitypub-inbox/page.tsx
@@ -1,0 +1,28 @@
+import { ActivityPubInboxLogList } from "~/components/dashboard/ActivityPubInboxLogList";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "~/components/ui/card";
+import { DefaultLayout } from "~/layouts/default";
+
+export default function ActivityPubInboxPage() {
+  return (
+    <DefaultLayout>
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-2">
+          <h1 className="text-3xl font-bold">ActivityPub 수신 로그</h1>
+          <p className="text-sm text-(--ink-soft)">
+            Inbox로 들어온 activity의 처리 상태와 원본 JSON-LD를 확인합니다.
+          </p>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Inbox 로그</CardTitle>
+            <CardDescription>실패하거나 무시된 activity를 추적할 수 있습니다.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <ActivityPubInboxLogList />
+          </CardContent>
+        </Card>
+      </div>
+    </DefaultLayout>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,9 +1,13 @@
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import { BugIcon } from "lucide-react";
+import Link from "next/link";
 
 import { ManageMainActor } from "~/components/dashboard/ManageMainActor";
 import { ManageUser } from "~/components/dashboard/ManageUser";
 import { PostList } from "~/components/dashboard/post/PostList";
 import { RecentCommentList } from "~/components/dashboard/RecentCommentList";
+import { Button } from "~/components/ui/button";
+import { Card, CardAction, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { DefaultLayout } from "~/layouts/default";
 import { getMainActor } from "~/lib/actions/actor";
 import { getUser } from "~/lib/actions/user";
@@ -26,6 +30,21 @@ export default function DashboardPage() {
     <DefaultLayout>
       <div className="flex flex-col gap-6">
         <h1 className="text-3xl font-bold">대시보드</h1>
+        <Card>
+          <CardHeader>
+            <CardTitle>운영 도구</CardTitle>
+            <CardAction>
+              <Link href="/dashboard/activitypub-inbox">
+                <Button variant="outline">
+                  <BugIcon /> ActivityPub 수신 로그
+                </Button>
+              </Link>
+            </CardAction>
+          </CardHeader>
+          <CardContent className="text-sm text-(--ink-soft)">
+            Inbox로 들어온 activity의 처리 상태와 원본 JSON-LD를 확인합니다.
+          </CardContent>
+        </Card>
         <PostList />
         <RecentCommentList />
 

--- a/src/components/dashboard/ActivityPubInboxLogList.tsx
+++ b/src/components/dashboard/ActivityPubInboxLogList.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { BugIcon } from "lucide-react";
+import { useState } from "react";
+
+import { AppPagination } from "~/components/AppPagination";
+import { Badge } from "~/components/ui/badge";
+import { Button } from "~/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "~/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/components/ui/select";
+import { Skeleton } from "~/components/ui/skeleton";
+import { PAGE_SIZE, PAGINATION_SIZE } from "~/constants";
+import { InboxActivityLog } from "~/generated/prisma";
+import { getInboxActivityLogs, getInboxActivityLogTypes } from "~/lib/actions/inboxActivityLog";
+import { cn } from "~/lib/utils";
+
+const statusLabels: Record<string, string> = {
+  received: "수신",
+  handled: "처리됨",
+  ignored: "무시됨",
+  failed: "실패",
+};
+
+export function ActivityPubInboxLogList() {
+  const [page, setPage] = useState(1);
+  const [status, setStatus] = useState("all");
+  const [activityType, setActivityType] = useState("all");
+  const [selectedLog, setSelectedLog] = useState<InboxActivityLog | null>(null);
+
+  const queryOptions = {
+    page,
+    limit: PAGE_SIZE,
+    status: status === "all" ? undefined : status,
+    activityType: activityType === "all" ? undefined : activityType,
+  };
+
+  const { data, status: queryStatus } = useQuery({
+    queryKey: ["inbox-activity-logs", queryOptions],
+    queryFn: () => getInboxActivityLogs(queryOptions),
+  });
+
+  const { data: activityTypes = [] } = useQuery({
+    queryKey: ["inbox-activity-log-types"],
+    queryFn: () => getInboxActivityLogTypes(),
+  });
+
+  function handleFilterChange(setter: (value: string) => void) {
+    return (value: string) => {
+      setter(value);
+      setPage(1);
+    };
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-2 sm:flex-row">
+        <Select value={status} onValueChange={handleFilterChange(setStatus)}>
+          <SelectTrigger className="w-full sm:w-36">
+            <SelectValue placeholder="상태" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">전체 상태</SelectItem>
+            <SelectItem value="received">수신</SelectItem>
+            <SelectItem value="handled">처리됨</SelectItem>
+            <SelectItem value="ignored">무시됨</SelectItem>
+            <SelectItem value="failed">실패</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <Select value={activityType} onValueChange={handleFilterChange(setActivityType)}>
+          <SelectTrigger className="w-full sm:w-44">
+            <SelectValue placeholder="Activity 타입" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">전체 타입</SelectItem>
+            {activityTypes.map((type) => (
+              <SelectItem key={type} value={type}>
+                {type}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {queryStatus === "pending" ? (
+        <LogListSkeleton />
+      ) : data?.records.length ? (
+        <>
+          <table className="hidden table-fixed lg:table">
+            <thead>
+              <tr className="*:p-2 *:text-left">
+                <th className="w-34">수신 시간</th>
+                <th className="w-24">상태</th>
+                <th className="w-28">타입</th>
+                <th>Actor</th>
+                <th>Object</th>
+                <th className="w-24"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.records.map((log) => (
+                <tr key={log.id} className="*:px-2 *:py-3">
+                  <td className="text-sm text-(--ink-soft)">{formatDate(log.receivedAt)}</td>
+                  <td>
+                    <StatusBadge status={log.status} />
+                  </td>
+                  <td className="font-medium">{log.activityType}</td>
+                  <td className="truncate text-sm">{log.actorUri ?? "-"}</td>
+                  <td className="truncate text-sm">{log.objectId ?? "-"}</td>
+                  <td className="text-right">
+                    <Button variant="outline" size="sm" onClick={() => setSelectedLog(log)}>
+                      자세히
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          <div className="flex flex-col gap-3 lg:hidden">
+            {data.records.map((log) => (
+              <button
+                key={log.id}
+                className="shadow(--shadow-soft) flex flex-col gap-2 rounded-3xl border-2 border-(--line) bg-(--paper) p-4 text-left text-(--ink)"
+                type="button"
+                onClick={() => setSelectedLog(log)}
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="font-bold">{log.activityType}</span>
+                  <StatusBadge status={log.status} />
+                </div>
+                <p className="text-sm break-all text-(--ink-soft)">
+                  {log.actorUri ?? "Actor 없음"}
+                </p>
+                <p className="text-xs text-(--ink-soft)">{formatDate(log.receivedAt)}</p>
+              </button>
+            ))}
+          </div>
+        </>
+      ) : (
+        <div className="flex flex-col items-center gap-2 rounded-3xl border-2 border-dashed border-(--line) p-8 text-center text-(--ink-soft)">
+          <BugIcon className="size-8" />
+          <p>조건에 맞는 수신 로그가 없습니다.</p>
+        </div>
+      )}
+
+      <AppPagination
+        total={data?.total ?? 0}
+        page={page}
+        limit={PAGE_SIZE}
+        size={PAGINATION_SIZE}
+        onPageChange={(newPage) => setPage(newPage)}
+      />
+
+      <LogDetailDialog log={selectedLog} onOpenChange={(open) => !open && setSelectedLog(null)} />
+    </div>
+  );
+}
+
+function LogListSkeleton() {
+  return (
+    <div className="flex flex-col gap-3">
+      {Array.from({ length: 4 }).map((_, index) => (
+        <Skeleton key={index} className="h-14 w-full" />
+      ))}
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  return (
+    <Badge
+      variant={status === "failed" ? "destructive" : status === "ignored" ? "outline" : "default"}
+      className={cn(status === "handled" && "bg-green-100 text-green-800")}
+    >
+      {statusLabels[status] ?? status}
+    </Badge>
+  );
+}
+
+function LogDetailDialog({
+  log,
+  onOpenChange,
+}: {
+  log: InboxActivityLog | null;
+  onOpenChange: (open: boolean) => void;
+}) {
+  return (
+    <Dialog open={log != null} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-4xl">
+        <DialogHeader>
+          <DialogTitle>ActivityPub 수신 로그</DialogTitle>
+          <DialogDescription>원본 JSON-LD와 처리 결과를 확인합니다.</DialogDescription>
+        </DialogHeader>
+
+        {log && (
+          <div className="flex flex-col gap-4 text-sm">
+            <div className="grid gap-2 rounded-2xl border border-(--line) p-4 sm:grid-cols-2">
+              <Info label="상태" value={<StatusBadge status={log.status} />} />
+              <Info label="타입" value={log.activityType} />
+              <Info label="수신 시간" value={formatDate(log.receivedAt)} />
+              <Info label="처리 시간" value={log.handledAt ? formatDate(log.handledAt) : "-"} />
+              <Info label="Activity ID" value={log.activityId ?? "-"} wide />
+              <Info label="Actor URI" value={log.actorUri ?? "-"} wide />
+              <Info label="Object ID" value={log.objectId ?? "-"} wide />
+              {log.errorMessage && <Info label="에러" value={log.errorMessage} wide />}
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <h2 className="font-bold">Raw JSON-LD</h2>
+              <pre className="max-h-[45vh] overflow-auto rounded-2xl bg-black p-4 text-xs whitespace-pre-wrap text-white">
+                {JSON.stringify(log.rawJson, null, 2)}
+              </pre>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function Info({ label, value, wide }: { label: string; value: React.ReactNode; wide?: boolean }) {
+  return (
+    <div className={cn("flex min-w-0 flex-col gap-1", wide && "sm:col-span-2")}>
+      <span className="text-xs text-(--ink-soft)">{label}</span>
+      <div className="font-medium break-all">{value}</div>
+    </div>
+  );
+}
+
+function formatDate(date: Date | string) {
+  return new Intl.DateTimeFormat("ko-KR", {
+    dateStyle: "short",
+    timeStyle: "medium",
+  }).format(new Date(date));
+}

--- a/src/federation.ts
+++ b/src/federation.ts
@@ -14,6 +14,7 @@ import { handleDelete } from "./federation/handleDelete";
 import { handleFollow } from "./federation/handleFollow";
 import { handleUndo } from "./federation/handleUndo";
 import { handleUpdate } from "./federation/handleUpdate";
+import { logInboxActivity } from "./federation/logInboxActivity";
 
 const redisUrl = process.env.REDIS_URL;
 
@@ -37,11 +38,11 @@ federation
 
 federation
   .setInboxListeners("/users/{identifier}/inbox", "/inbox")
-  .on(Follow, handleFollow)
-  .on(Undo, handleUndo)
-  .on(Create, handleCreate)
-  .on(Delete, handleDelete)
-  .on(Update, handleUpdate);
+  .on(Follow, logInboxActivity(handleFollow))
+  .on(Undo, logInboxActivity(handleUndo))
+  .on(Create, logInboxActivity(handleCreate))
+  .on(Delete, logInboxActivity(handleDelete))
+  .on(Update, logInboxActivity(handleUpdate));
 
 federation
   .setFollowersDispatcher("/users/{identifier}/followers", dispatchFollowers)

--- a/src/federation/handleCreate.ts
+++ b/src/federation/handleCreate.ts
@@ -9,64 +9,65 @@ import {
   upsertActor,
 } from "~/lib/utils-federation";
 
+import type { InboxActivityStatus } from "./logInboxActivity";
 import type { Create, InboxContext } from "@fedify/fedify";
 
-export async function handleCreate(_ctx: InboxContext<unknown>, create: Create) {
-  try {
-    log(`Received Create activity: ${create.id?.href}`);
+export async function handleCreate(
+  _ctx: InboxContext<unknown>,
+  create: Create,
+): Promise<InboxActivityStatus> {
+  log(`Received Create activity: ${create.id?.href}`);
 
-    const object = await create.getObject();
-    if (!(object instanceof Note)) return;
+  const object = await create.getObject();
+  if (!(object instanceof Note)) return "ignored";
 
-    const actor = create.actorId;
-    if (actor == null) return;
+  const actor = create.actorId;
+  if (actor == null) return "ignored";
 
-    const author = await object.getAttribution();
-    if (!isActor(author) || author.id?.href !== actor.href) return;
+  const author = await object.getAttribution();
+  if (!isActor(author) || author.id?.href !== actor.href) return "ignored";
 
-    const replyTarget = await object.getReplyTarget();
-    if (replyTarget == null || !(replyTarget instanceof Note)) {
-      log("The Note does not have an replyTarget, skipping");
-      return;
-    }
-
-    const uri = replyTarget.id?.toString();
-    const post = await prisma.posts.findFirst({ where: { uri } });
-    const parentComment = await prisma.comment.findFirst({ where: { uri } });
-
-    if (!post && !parentComment) {
-      log("replyTarget target not found in posts or comments");
-      return;
-    }
-
-    const actorRecord = await upsertActor(author);
-    if (!actorRecord || object.id == null) return;
-
-    try {
-      await prisma.comment.create({
-        data: {
-          uri: object.id.href,
-          actorId: actorRecord.id,
-          postId: post?.id ?? parentComment!.postId,
-          parentId: parentComment?.id ?? null,
-          content: object.content?.toString() || "",
-          url: object.url?.href?.toString(),
-          to: object.toIds.map((to) => to.href),
-          cc: object.ccIds.map((cc) => cc.href),
-          mentions: getTagFromNote(object),
-          attachment: { createMany: { data: await formatNoteAttachments(object) } },
-        },
-      });
-    } catch (error) {
-      if (isUniqueConstraintError(error)) {
-        log(`Comment already exists, skipping duplicate Create: ${object.id.href}`);
-        return;
-      }
-      throw error;
-    }
-
-    log(`Saved comment: ${object.id.href}`);
-  } catch (error) {
-    log("Error processing Create activity:", error);
+  const replyTarget = await object.getReplyTarget();
+  if (replyTarget == null || !(replyTarget instanceof Note)) {
+    log("The Note does not have an replyTarget, skipping");
+    return "ignored";
   }
+
+  const uri = replyTarget.id?.toString();
+  const post = await prisma.posts.findFirst({ where: { uri } });
+  const parentComment = await prisma.comment.findFirst({ where: { uri } });
+
+  if (!post && !parentComment) {
+    log("replyTarget target not found in posts or comments");
+    return "ignored";
+  }
+
+  const actorRecord = await upsertActor(author);
+  if (!actorRecord || object.id == null) return "ignored";
+
+  try {
+    await prisma.comment.create({
+      data: {
+        uri: object.id.href,
+        actorId: actorRecord.id,
+        postId: post?.id ?? parentComment!.postId,
+        parentId: parentComment?.id ?? null,
+        content: object.content?.toString() || "",
+        url: object.url?.href?.toString(),
+        to: object.toIds.map((to) => to.href),
+        cc: object.ccIds.map((cc) => cc.href),
+        mentions: getTagFromNote(object),
+        attachment: { createMany: { data: await formatNoteAttachments(object) } },
+      },
+    });
+  } catch (error) {
+    if (isUniqueConstraintError(error)) {
+      log(`Comment already exists, skipping duplicate Create: ${object.id.href}`);
+      return "ignored";
+    }
+    throw error;
+  }
+
+  log(`Saved comment: ${object.id.href}`);
+  return "handled";
 }

--- a/src/federation/handleDelete.ts
+++ b/src/federation/handleDelete.ts
@@ -1,15 +1,19 @@
 import { log } from "./log";
 import { prisma } from "~/lib/prisma";
 
+import type { InboxActivityStatus } from "./logInboxActivity";
 import type { Delete, InboxContext } from "@fedify/fedify";
 
-export async function handleDelete(_ctx: InboxContext<unknown>, del: Delete) {
+export async function handleDelete(
+  _ctx: InboxContext<unknown>,
+  del: Delete,
+): Promise<InboxActivityStatus> {
   log(`Received Delete activity: ${del.id?.href}`);
 
   const objectId = del.objectId;
   if (objectId == null) {
     log("The Delete object does not have an objectId:", del);
-    return;
+    return "ignored";
   }
 
   const comment = await prisma.comment.findFirst({
@@ -19,16 +23,17 @@ export async function handleDelete(_ctx: InboxContext<unknown>, del: Delete) {
 
   if (!comment) {
     log(`Comment not found for deletion: ${objectId.href}`);
-    return;
+    return "ignored";
   }
 
   if (del.actorId?.href !== comment.actor.uri) {
     log(
       `Unauthorized delete attempt. Request actor: ${del.actorId?.href}, Comment actor: ${comment.actor.uri}`,
     );
-    return;
+    return "ignored";
   }
 
   await prisma.comment.delete({ where: { id: comment.id } });
   log(`Deleted comment: ${comment.id}`);
+  return "handled";
 }

--- a/src/federation/handleFollow.ts
+++ b/src/federation/handleFollow.ts
@@ -4,26 +4,30 @@ import { log } from "./log";
 import { prisma } from "~/lib/prisma";
 import { isUniqueConstraintError, upsertActor } from "~/lib/utils-federation";
 
+import type { InboxActivityStatus } from "./logInboxActivity";
 import type { Follow, InboxContext } from "@fedify/fedify";
 
-export async function handleFollow(ctx: InboxContext<unknown>, follow: Follow) {
+export async function handleFollow(
+  ctx: InboxContext<unknown>,
+  follow: Follow,
+): Promise<InboxActivityStatus> {
   log(`Received Follow activity: ${follow.id?.href}`);
 
   if (follow.objectId == null) {
     log("The Follow object does not have an object:", follow);
-    return;
+    return "ignored";
   }
 
   const object = ctx.parseUri(follow.objectId);
   if (object == null || object.type !== "actor") {
     log("The Follow object's object is not an actor:", follow);
-    return;
+    return "ignored";
   }
 
   const follower = await follow.getActor();
   if (follower?.id == null || follower.inboxId == null) {
     log("The Follow object does not have an actor:", follow);
-    return;
+    return "ignored";
   }
 
   log(
@@ -42,7 +46,7 @@ export async function handleFollow(ctx: InboxContext<unknown>, follow: Follow) {
 
   if (followingId == null) {
     log("Failed to find the actor to follow in the database:", object);
-    return;
+    return "ignored";
   }
 
   const followerId = (await upsertActor(follower)).id;
@@ -57,7 +61,7 @@ export async function handleFollow(ctx: InboxContext<unknown>, follow: Follow) {
   } catch (error) {
     if (!isUniqueConstraintError(error)) {
       log("Error creating follow relationship:", error);
-      return;
+      throw error;
     }
 
     log("Follow relationship already exists; accepting again:", error);
@@ -73,4 +77,6 @@ export async function handleFollow(ctx: InboxContext<unknown>, follow: Follow) {
     }),
     { immediate: true },
   );
+
+  return "handled";
 }

--- a/src/federation/handleUndo.ts
+++ b/src/federation/handleUndo.ts
@@ -3,17 +3,21 @@ import { Follow } from "@fedify/fedify";
 import { log } from "./log";
 import { prisma } from "~/lib/prisma";
 
+import type { InboxActivityStatus } from "./logInboxActivity";
 import type { InboxContext, Undo } from "@fedify/fedify";
 
-export async function handleUndo(ctx: InboxContext<unknown>, undo: Undo) {
+export async function handleUndo(
+  ctx: InboxContext<unknown>,
+  undo: Undo,
+): Promise<InboxActivityStatus> {
   log(`Received Undo activity: ${undo.id?.href}`);
 
   const object = await undo.getObject();
-  if (!(object instanceof Follow)) return;
-  if (undo.actorId == null || object.objectId == null) return;
+  if (!(object instanceof Follow)) return "ignored";
+  if (undo.actorId == null || object.objectId == null) return "ignored";
 
   const parsed = ctx.parseUri(object.objectId);
-  if (parsed == null || parsed.type !== "actor") return;
+  if (parsed == null || parsed.type !== "actor") return "ignored";
 
   const followingActor = await prisma.actor.findFirst({
     where: {
@@ -31,7 +35,7 @@ export async function handleUndo(ctx: InboxContext<unknown>, undo: Undo) {
 
   if (!followingActor || !followerActor) {
     log("Either following or follower actor not found.");
-    return;
+    return "ignored";
   }
 
   log(`Processing unfollow from ${followerActor.handle} to @${followingActor.handle}`);
@@ -42,4 +46,6 @@ export async function handleUndo(ctx: InboxContext<unknown>, undo: Undo) {
       followerId: followerActor.id,
     },
   });
+
+  return "handled";
 }

--- a/src/federation/handleUpdate.ts
+++ b/src/federation/handleUpdate.ts
@@ -4,16 +4,20 @@ import { log } from "./log";
 import { prisma } from "~/lib/prisma";
 import { formatNoteAttachments, getTagFromNote, upsertActor } from "~/lib/utils-federation";
 
+import type { InboxActivityStatus } from "./logInboxActivity";
 import type { InboxContext, Update } from "@fedify/fedify";
 
-export async function handleUpdate(_ctx: InboxContext<unknown>, update: Update) {
+export async function handleUpdate(
+  _ctx: InboxContext<unknown>,
+  update: Update,
+): Promise<InboxActivityStatus> {
   log(`Received Update activity: ${update.id?.href}`);
 
   const object = await update.getObject();
-  if (!object) return;
+  if (!object) return "ignored";
 
   if (object instanceof Note) {
-    if (object.id == null) return;
+    if (object.id == null) return "ignored";
 
     const comment = await prisma.comment.findFirst({
       where: { uri: object.id.href },
@@ -22,14 +26,14 @@ export async function handleUpdate(_ctx: InboxContext<unknown>, update: Update) 
 
     if (!comment) {
       log(`Comment not found for update: ${object.id.href}`);
-      return;
+      return "ignored";
     }
 
     if (update.actorId?.href !== comment.actor.uri) {
       log(
         `Unauthorized update attempt. Request actor: ${update.actorId?.href}, Comment actor: ${comment.actor.uri}`,
       );
-      return;
+      return "ignored";
     }
 
     await prisma.comment.update({
@@ -48,16 +52,19 @@ export async function handleUpdate(_ctx: InboxContext<unknown>, update: Update) 
     });
 
     log(`Updated comment: ${comment.id}`);
-    return;
+    return "handled";
   }
 
   if (isActor(object)) {
     if (update.actorId?.href !== object.id?.href) {
       log("Unauthorized actor update attempt: Actor can only update themselves");
-      return;
+      return "ignored";
     }
 
     await upsertActor(object);
     log(`Updated actor profile: ${object.id?.href}`);
+    return "handled";
   }
+
+  return "ignored";
 }

--- a/src/federation/logInboxActivity.ts
+++ b/src/federation/logInboxActivity.ts
@@ -1,0 +1,50 @@
+import { prisma } from "~/lib/prisma";
+
+import type { Activity, InboxContext } from "@fedify/fedify";
+import type { Prisma } from "~/generated/prisma";
+
+export type InboxActivityStatus = "handled" | "ignored";
+export type InboxActivityHandler<TActivity extends Activity> = (
+  ctx: InboxContext<unknown>,
+  activity: TActivity,
+) => Promise<InboxActivityStatus>;
+
+export function logInboxActivity<TActivity extends Activity>(
+  handler: InboxActivityHandler<TActivity>,
+) {
+  return async (ctx: InboxContext<unknown>, activity: TActivity) => {
+    const rawJson = await activity.toJsonLd({ format: "compact" });
+    const logRecord = await prisma.inboxActivityLog.create({
+      data: {
+        activityId: activity.id?.href,
+        activityType: activity.constructor.name,
+        actorUri: activity.actorId?.href,
+        objectId: activity.objectId?.href,
+        rawJson: toPrismaJson(rawJson),
+        status: "received",
+      },
+    });
+
+    try {
+      const status = await handler(ctx, activity);
+      await prisma.inboxActivityLog.update({
+        where: { id: logRecord.id },
+        data: { status, handledAt: new Date() },
+      });
+    } catch (error) {
+      await prisma.inboxActivityLog.update({
+        where: { id: logRecord.id },
+        data: {
+          status: "failed",
+          errorMessage: error instanceof Error ? error.message : String(error),
+          handledAt: new Date(),
+        },
+      });
+      throw error;
+    }
+  };
+}
+
+function toPrismaJson(value: unknown): Prisma.InputJsonValue {
+  return JSON.parse(JSON.stringify(value)) as Prisma.InputJsonValue;
+}

--- a/src/lib/actions/inboxActivityLog.ts
+++ b/src/lib/actions/inboxActivityLog.ts
@@ -1,0 +1,44 @@
+"use server";
+
+import { prisma } from "~/lib/prisma";
+import { getValidAdminSession } from "~/lib/utils-server";
+
+export async function getInboxActivityLogs(options?: {
+  page?: number;
+  limit?: number;
+  status?: string;
+  activityType?: string;
+}) {
+  await getValidAdminSession();
+
+  const page = options?.page ?? 1;
+  const limit = options?.limit ?? 10;
+  const where = {
+    ...(options?.status ? { status: options.status } : {}),
+    ...(options?.activityType ? { activityType: options.activityType } : {}),
+  };
+
+  const [records, total] = await Promise.all([
+    prisma.inboxActivityLog.findMany({
+      where,
+      orderBy: { receivedAt: "desc" },
+      skip: (page - 1) * limit,
+      take: limit,
+    }),
+    prisma.inboxActivityLog.count({ where }),
+  ]);
+
+  return { records, total };
+}
+
+export async function getInboxActivityLogTypes() {
+  await getValidAdminSession();
+
+  const records = await prisma.inboxActivityLog.findMany({
+    distinct: ["activityType"],
+    orderBy: { activityType: "asc" },
+    select: { activityType: true },
+  });
+
+  return records.map((record) => record.activityType);
+}

--- a/src/prisma/migrations/20260701000000_add_inbox_activity_log/migration.sql
+++ b/src/prisma/migrations/20260701000000_add_inbox_activity_log/migration.sql
@@ -1,0 +1,20 @@
+CREATE TABLE "inbox_activity_log" (
+    "id" TEXT NOT NULL,
+    "activityId" TEXT,
+    "activityType" TEXT NOT NULL,
+    "actorUri" TEXT,
+    "objectId" TEXT,
+    "rawJson" JSONB NOT NULL,
+    "status" TEXT NOT NULL,
+    "errorMessage" TEXT,
+    "receivedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "handledAt" TIMESTAMP(3),
+
+    CONSTRAINT "inbox_activity_log_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "inbox_activity_log_activityId_idx" ON "inbox_activity_log"("activityId");
+CREATE INDEX "inbox_activity_log_activityType_idx" ON "inbox_activity_log"("activityType");
+CREATE INDEX "inbox_activity_log_actorUri_idx" ON "inbox_activity_log"("actorUri");
+CREATE INDEX "inbox_activity_log_status_idx" ON "inbox_activity_log"("status");
+CREATE INDEX "inbox_activity_log_receivedAt_idx" ON "inbox_activity_log"("receivedAt");

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -67,6 +67,26 @@ model Follows {
   @@map("follows")
 }
 
+model InboxActivityLog {
+  id           String    @id @default(uuid(7))
+  activityId   String?
+  activityType String
+  actorUri     String?
+  objectId     String?
+  rawJson      Json
+  status       String
+  errorMessage String?
+  receivedAt   DateTime  @default(now())
+  handledAt    DateTime?
+
+  @@index([activityId])
+  @@index([activityType])
+  @@index([actorUri])
+  @@index([status])
+  @@index([receivedAt])
+  @@map("inbox_activity_log")
+}
+
 model Posts {
   id          String    @id @default(uuid(7))
   uri         String    @unique

--- a/src/tests/federation.handleCreate.test.ts
+++ b/src/tests/federation.handleCreate.test.ts
@@ -112,6 +112,6 @@ describe("handleCreate", () => {
         actorId: author.id,
         getObject: vi.fn(async () => note),
       } as Pick<Create, "actorId" | "getObject"> as Create),
-    ).resolves.toBeUndefined();
+    ).resolves.toBe("ignored");
   });
 });

--- a/src/tests/federation.handleFollow.test.ts
+++ b/src/tests/federation.handleFollow.test.ts
@@ -45,7 +45,7 @@ describe("handleFollow", () => {
     expect(ctx.sendActivity).toHaveBeenCalledTimes(1);
   });
 
-  it("does not accept Follow activities when persistence fails for a non-unique error", async () => {
+  it("throws when Follow persistence fails for a non-unique error", async () => {
     const ctx = createCtx();
     const follower = createRemoteActor();
     const follow = new Follow({
@@ -57,7 +57,7 @@ describe("handleFollow", () => {
     mocks.upsertActor.mockResolvedValueOnce({ id: "remote-actor" });
     mocks.prisma.follows.create.mockRejectedValueOnce(new Error("db down"));
 
-    await handleFollow(ctx, follow);
+    await expect(handleFollow(ctx, follow)).rejects.toThrow("db down");
 
     expect(ctx.sendActivity).not.toHaveBeenCalled();
   });

--- a/src/tests/federation.helpers.ts
+++ b/src/tests/federation.helpers.ts
@@ -9,6 +9,7 @@ vi.hoisted(() => {
       actor: { findFirst: vi.fn() },
       keys: { upsert: vi.fn() },
       follows: { create: vi.fn(), deleteMany: vi.fn(), findMany: vi.fn(), count: vi.fn() },
+      inboxActivityLog: { create: vi.fn(), update: vi.fn(), findMany: vi.fn(), count: vi.fn() },
       posts: { count: vi.fn(), findFirst: vi.fn(), findMany: vi.fn() },
       comment: { create: vi.fn(), delete: vi.fn(), findFirst: vi.fn(), update: vi.fn() },
     },
@@ -24,6 +25,12 @@ type FederationTestMocks = {
     follows: {
       create: ReturnType<typeof vi.fn>;
       deleteMany: ReturnType<typeof vi.fn>;
+      findMany: ReturnType<typeof vi.fn>;
+      count: ReturnType<typeof vi.fn>;
+    };
+    inboxActivityLog: {
+      create: ReturnType<typeof vi.fn>;
+      update: ReturnType<typeof vi.fn>;
       findMany: ReturnType<typeof vi.fn>;
       count: ReturnType<typeof vi.fn>;
     };

--- a/src/tests/federation.logInboxActivity.test.ts
+++ b/src/tests/federation.logInboxActivity.test.ts
@@ -1,0 +1,54 @@
+import { Follow } from "@fedify/fedify";
+
+import { createCtx, mocks } from "./federation.helpers";
+
+const { logInboxActivity } = await import("../federation/logInboxActivity");
+
+describe("logInboxActivity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.prisma.inboxActivityLog.create.mockResolvedValue({ id: "log-1" });
+  });
+
+  it("records incoming activity metadata and handled status", async () => {
+    const follow = new Follow({
+      id: new URL("https://remote.test/activities/follow-1"),
+      actor: new URL("https://remote.test/users/bob"),
+      object: new URL("https://example.com/users/alice"),
+    });
+    const handler = vi.fn(async () => "handled" as const);
+
+    await logInboxActivity(handler)(createCtx(), follow);
+
+    expect(mocks.prisma.inboxActivityLog.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        activityId: "https://remote.test/activities/follow-1",
+        activityType: "Follow",
+        actorUri: "https://remote.test/users/bob",
+        objectId: "https://example.com/users/alice",
+        status: "received",
+      }),
+    });
+    expect(mocks.prisma.inboxActivityLog.update).toHaveBeenCalledWith({
+      where: { id: "log-1" },
+      data: { status: "handled", handledAt: expect.any(Date) },
+    });
+  });
+
+  it("records failed status and rethrows handler errors", async () => {
+    const follow = new Follow({
+      actor: new URL("https://remote.test/users/bob"),
+      object: new URL("https://example.com/users/alice"),
+    });
+    const handler = vi.fn(async () => {
+      throw new Error("boom");
+    });
+
+    await expect(logInboxActivity(handler)(createCtx(), follow)).rejects.toThrow("boom");
+
+    expect(mocks.prisma.inboxActivityLog.update).toHaveBeenCalledWith({
+      where: { id: "log-1" },
+      data: { status: "failed", errorMessage: "boom", handledAt: expect.any(Date) },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `InboxActivityLog` persistence for received ActivityPub inbox activities
- Wrap inbox handlers to record `received`, `handled`, `ignored`, and `failed` states with raw JSON-LD
- Add an admin dashboard page to filter, inspect, and view raw inbox activity logs

## Tests
- `pnpm format`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

Closes #82