### PR TITLE
업로드 파일 검증 강화

### DIFF
--- a/src/lib/models/s3.ts
+++ b/src/lib/models/s3.ts
@@ -1,4 +1,5 @@
 import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { randomUUID } from "crypto";
 
 if (
   !process.env.S3_ENDPOINT ||
@@ -19,18 +20,89 @@ const client = new S3Client({
   },
 });
 
+const MAX_UPLOAD_SIZE = 10 * 1024 * 1024;
+const ALLOWED_IMAGE_TYPES = new Map([
+  ["image/jpeg", "jpg"],
+  ["image/png", "png"],
+  ["image/gif", "gif"],
+  ["image/webp", "webp"],
+  ["image/avif", "avif"],
+]);
+
+function detectImageType(buffer: Buffer) {
+  if (buffer.subarray(0, 3).equals(Buffer.from([0xff, 0xd8, 0xff]))) {
+    return "image/jpeg";
+  }
+
+  if (buffer.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))) {
+    return "image/png";
+  }
+
+  if (
+    buffer.subarray(0, 6).equals(Buffer.from("GIF87a")) ||
+    buffer.subarray(0, 6).equals(Buffer.from("GIF89a"))
+  ) {
+    return "image/gif";
+  }
+
+  if (
+    buffer.subarray(0, 4).equals(Buffer.from("RIFF")) &&
+    buffer.subarray(8, 12).equals(Buffer.from("WEBP"))
+  ) {
+    return "image/webp";
+  }
+
+  if (buffer.subarray(4, 12).equals(Buffer.from("ftypavif"))) {
+    return "image/avif";
+  }
+}
+
+function validateUploadFile(file: File, buffer: Buffer) {
+  if (file.size === 0 || buffer.length === 0) {
+    throw new Error("빈 파일은 업로드할 수 없습니다.");
+  }
+
+  if (file.size > MAX_UPLOAD_SIZE || buffer.length > MAX_UPLOAD_SIZE) {
+    throw new Error("파일 크기는 10MB를 초과할 수 없습니다.");
+  }
+
+  if (file.type && !ALLOWED_IMAGE_TYPES.has(file.type)) {
+    throw new Error("업로드할 수 없는 파일 형식입니다.");
+  }
+
+  const detectedType = detectImageType(buffer);
+
+  if (!detectedType || !ALLOWED_IMAGE_TYPES.has(detectedType)) {
+    throw new Error("실제 이미지 파일만 업로드할 수 있습니다.");
+  }
+
+  if (file.type && file.type !== detectedType) {
+    throw new Error("파일 형식과 실제 이미지 형식이 일치하지 않습니다.");
+  }
+
+  return {
+    contentType: detectedType,
+    extension: ALLOWED_IMAGE_TYPES.get(detectedType)!,
+  };
+}
+
 export async function uploadFile(file: File, path: string) {
   const buffer = Buffer.from(await file.arrayBuffer());
-  const filename = `${file.name}-${Date.now()}.${file.type.split("/")[1]}`;
+  const { contentType, extension } = validateUploadFile(file, buffer);
+  const filename = `${randomUUID()}.${extension}`;
 
   const command = new PutObjectCommand({
     Bucket: process.env.S3_BUCKET,
     Key: `${path}/${filename}`,
     Body: buffer,
-    ContentType: file.type,
+    ContentType: contentType,
   });
 
-  await client.send(command);
+  try {
+    await client.send(command);
+  } catch {
+    throw new Error("파일 업로드에 실패했습니다.");
+  }
 
   return `${process.env.S3_PUBLIC_URL}/${path}/${filename}`;
 }

--- a/src/lib/utils-federation.ts
+++ b/src/lib/utils-federation.ts
@@ -34,7 +34,7 @@ export async function upsertActor(actor: Awaited<ReturnType<Activity["getActor"]
         [iconArrayBuffer],
         icon.url.toString().split("/").pop() || "avatar",
         {
-          type: icon.mediaType?.toString() || "image/jpeg",
+          type: icon.mediaType?.toString() || "",
         },
       );
       uploadedUrl = await uploadFile(iconFile, "remote-contents");

--- a/src/tests/s3.model.test.ts
+++ b/src/tests/s3.model.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const s3Mocks = vi.hoisted(() => ({
+  send: vi.fn(),
+  commands: [] as Array<Record<string, unknown>>,
+}));
+
+vi.mock("@aws-sdk/client-s3", () => ({
+  PutObjectCommand: class {
+    constructor(input: Record<string, unknown>) {
+      s3Mocks.commands.push(input);
+    }
+  },
+  S3Client: class {
+    send = s3Mocks.send;
+  },
+}));
+
+function pngBytes() {
+  return new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+}
+
+async function importUploadFile() {
+  vi.resetModules();
+
+  process.env.S3_ENDPOINT = "https://s3.example.com";
+  process.env.S3_ACCESS_KEY_ID = "access-key";
+  process.env.S3_SECRET_ACCESS_KEY = "secret-key";
+  process.env.S3_BUCKET = "bucket";
+  process.env.S3_PUBLIC_URL = "https://cdn.example.com";
+
+  return await import("../lib/models/s3");
+}
+
+describe("uploadFile", () => {
+  beforeEach(() => {
+    s3Mocks.send.mockReset();
+    s3Mocks.commands.length = 0;
+  });
+
+  it("uploads validated images with a UUID object key", async () => {
+    const { uploadFile } = await importUploadFile();
+    const file = new File([pngBytes()], "original-name.png", { type: "image/png" });
+
+    const url = await uploadFile(file, "medias");
+
+    expect(s3Mocks.send).toHaveBeenCalledTimes(1);
+    expect(s3Mocks.commands).toHaveLength(1);
+    expect(s3Mocks.commands[0]).toMatchObject({
+      Bucket: "bucket",
+      Body: Buffer.from(pngBytes()),
+      ContentType: "image/png",
+    });
+    expect(s3Mocks.commands[0]?.Key).toMatch(
+      /^medias\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.png$/,
+    );
+    expect(String(s3Mocks.commands[0]?.Key)).not.toContain("original-name");
+    expect(url).toBe(`https://cdn.example.com/${s3Mocks.commands[0]?.Key}`);
+  });
+
+  it("rejects unsupported MIME types before uploading", async () => {
+    const { uploadFile } = await importUploadFile();
+    const file = new File([pngBytes()], "image.svg", { type: "image/svg+xml" });
+
+    await expect(uploadFile(file, "medias")).rejects.toThrow("업로드할 수 없는 파일 형식입니다.");
+    expect(s3Mocks.send).not.toHaveBeenCalled();
+  });
+
+  it("rejects files whose bytes are not an allowed image", async () => {
+    const { uploadFile } = await importUploadFile();
+    const file = new File(["not an image"], "image.png", { type: "image/png" });
+
+    await expect(uploadFile(file, "medias")).rejects.toThrow(
+      "실제 이미지 파일만 업로드할 수 있습니다.",
+    );
+    expect(s3Mocks.send).not.toHaveBeenCalled();
+  });
+
+  it("rejects files larger than 10MB before uploading", async () => {
+    const { uploadFile } = await importUploadFile();
+    const bytes = new Uint8Array(10 * 1024 * 1024 + 1);
+    bytes.set(pngBytes());
+    const file = new File([bytes], "large.png", { type: "image/png" });
+
+    await expect(uploadFile(file, "medias")).rejects.toThrow(
+      "파일 크기는 10MB를 초과할 수 없습니다.",
+    );
+    expect(s3Mocks.send).not.toHaveBeenCalled();
+  });
+
+  it("wraps S3 upload errors", async () => {
+    s3Mocks.send.mockRejectedValueOnce(new Error("provider failed"));
+    const { uploadFile } = await importUploadFile();
+    const file = new File([pngBytes()], "image.png", { type: "image/png" });
+
+    await expect(uploadFile(file, "medias")).rejects.toThrow("파일 업로드에 실패했습니다.");
+  });
+});


### PR DESCRIPTION
## Summary
- S3 업로드 전에 이미지 MIME allowlist, 최대 10MB 크기 제한, 실제 이미지 매직 바이트 검증을 추가했습니다.
- 원본 파일명 대신 UUID 기반 object key를 사용하고, 확장자는 감지된 이미지 타입으로 결정하도록 변경했습니다.
- S3 업로드 실패 메시지를 정리하고 관련 모델 테스트를 추가했습니다.

## Tests
- `pnpm format`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

Closes #83