### PR TITLE
업로드 이미지를 WebP로 변환

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "react-dom": "19.1.0",
     "react-hook-form": "^7.65.0",
     "server-only": "^0.0.1",
+    "sharp": "0.34.5",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
     "usehooks-ts": "^3.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
+      sharp:
+        specifier: 0.34.5
+        version: 0.34.5
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -4332,8 +4335,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@img/colour@1.1.0':
-    optional: true
+  '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
@@ -7075,7 +7077,6 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:

--- a/src/lib/models/s3.ts
+++ b/src/lib/models/s3.ts
@@ -1,6 +1,8 @@
 import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import { randomUUID } from "crypto";
 
+import { convertImageBufferToWebp } from "../utils-image";
+
 if (
   !process.env.S3_ENDPOINT ||
   !process.env.S3_ACCESS_KEY_ID ||
@@ -21,12 +23,12 @@ const client = new S3Client({
 });
 
 const MAX_UPLOAD_SIZE = 10 * 1024 * 1024;
-const ALLOWED_IMAGE_TYPES = new Map([
-  ["image/jpeg", "jpg"],
-  ["image/png", "png"],
-  ["image/gif", "gif"],
-  ["image/webp", "webp"],
-  ["image/avif", "avif"],
+const ALLOWED_IMAGE_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "image/avif",
 ]);
 
 function detectImageType(buffer: Buffer) {
@@ -79,23 +81,19 @@ function validateUploadFile(file: File, buffer: Buffer) {
   if (file.type && file.type !== detectedType) {
     throw new Error("파일 형식과 실제 이미지 형식이 일치하지 않습니다.");
   }
-
-  return {
-    contentType: detectedType,
-    extension: ALLOWED_IMAGE_TYPES.get(detectedType)!,
-  };
 }
 
 export async function uploadFile(file: File, path: string) {
   const buffer = Buffer.from(await file.arrayBuffer());
-  const { contentType, extension } = validateUploadFile(file, buffer);
-  const filename = `${randomUUID()}.${extension}`;
+  validateUploadFile(file, buffer);
+  const optimizedBuffer = await convertImageBufferToWebp(buffer);
+  const filename = `${randomUUID()}.webp`;
 
   const command = new PutObjectCommand({
     Bucket: process.env.S3_BUCKET,
     Key: `${path}/${filename}`,
-    Body: buffer,
-    ContentType: contentType,
+    Body: optimizedBuffer,
+    ContentType: "image/webp",
   });
 
   try {

--- a/src/lib/utils-image.ts
+++ b/src/lib/utils-image.ts
@@ -1,0 +1,5 @@
+import sharp from "sharp";
+
+export async function convertImageBufferToWebp(buffer: Buffer) {
+  return await sharp(buffer).rotate().webp({ quality: 85 }).toBuffer();
+}

--- a/src/tests/s3.model.test.ts
+++ b/src/tests/s3.model.test.ts
@@ -5,6 +5,10 @@ const s3Mocks = vi.hoisted(() => ({
   commands: [] as Array<Record<string, unknown>>,
 }));
 
+const imageMocks = vi.hoisted(() => ({
+  convertImageBufferToWebp: vi.fn(async (buffer: Buffer) => buffer),
+}));
+
 vi.mock("@aws-sdk/client-s3", () => ({
   PutObjectCommand: class {
     constructor(input: Record<string, unknown>) {
@@ -15,6 +19,8 @@ vi.mock("@aws-sdk/client-s3", () => ({
     send = s3Mocks.send;
   },
 }));
+
+vi.mock("../lib/utils-image", () => imageMocks);
 
 function pngBytes() {
   return new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
@@ -36,6 +42,8 @@ describe("uploadFile", () => {
   beforeEach(() => {
     s3Mocks.send.mockReset();
     s3Mocks.commands.length = 0;
+    imageMocks.convertImageBufferToWebp.mockReset();
+    imageMocks.convertImageBufferToWebp.mockImplementation(async (buffer: Buffer) => buffer);
   });
 
   it("uploads validated images with a UUID object key", async () => {
@@ -49,13 +57,25 @@ describe("uploadFile", () => {
     expect(s3Mocks.commands[0]).toMatchObject({
       Bucket: "bucket",
       Body: Buffer.from(pngBytes()),
-      ContentType: "image/png",
+      ContentType: "image/webp",
     });
+    expect(imageMocks.convertImageBufferToWebp).toHaveBeenCalledWith(Buffer.from(pngBytes()));
     expect(s3Mocks.commands[0]?.Key).toMatch(
-      /^medias\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.png$/,
+      /^medias\/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.webp$/,
     );
     expect(String(s3Mocks.commands[0]?.Key)).not.toContain("original-name");
     expect(url).toBe(`https://cdn.example.com/${s3Mocks.commands[0]?.Key}`);
+  });
+
+  it("uploads optimized image bytes", async () => {
+    const optimizedBuffer = Buffer.from("optimized image");
+    imageMocks.convertImageBufferToWebp.mockResolvedValueOnce(optimizedBuffer);
+    const { uploadFile } = await importUploadFile();
+    const file = new File([pngBytes()], "image.png", { type: "image/png" });
+
+    await uploadFile(file, "medias");
+
+    expect(s3Mocks.commands[0]?.Body).toBe(optimizedBuffer);
   });
 
   it("rejects unsupported MIME types before uploading", async () => {

--- a/src/tests/utils-image.test.ts
+++ b/src/tests/utils-image.test.ts
@@ -1,0 +1,25 @@
+import sharp from "sharp";
+import { describe, expect, it } from "vitest";
+
+import { convertImageBufferToWebp } from "../lib/utils-image";
+
+describe("convertImageBufferToWebp", () => {
+  it("converts supported image buffers to webp", async () => {
+    const input = await sharp({
+      create: {
+        width: 16,
+        height: 16,
+        channels: 3,
+        background: "red",
+      },
+    })
+      .png()
+      .toBuffer();
+
+    const output = await convertImageBufferToWebp(input);
+    const metadata = await sharp(output).metadata();
+
+    expect(Buffer.isBuffer(output)).toBe(true);
+    expect(metadata.format).toBe("webp");
+  });
+});


### PR DESCRIPTION
## Summary
- 업로드 이미지 검증 후 `sharp`로 WebP 변환 유틸 적용
- S3 업로드 객체 키와 Content-Type을 WebP 기준으로 저장
- 업로드/변환 테스트 추가 및 갱신

Closes #36

## Test
- `pnpm format`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`