### PR TITLE
이모지 리액션 연동

### DIFF
--- a/src/app/post/[slug]/PostPage.tsx
+++ b/src/app/post/[slug]/PostPage.tsx
@@ -7,6 +7,7 @@ import { useMemo } from "react";
 import { PostDropdownMenu } from "~/components/dashboard/post/PostPaginationList";
 import { PostComments } from "~/components/post/PostComment";
 import { PostToc, TocHeading } from "~/components/post/PostToc";
+import { ReactionButton } from "~/components/post/ReactionButton";
 import { Badge } from "~/components/ui/badge";
 import { Image as ImageType, User } from "~/generated/prisma";
 import { usePost } from "~/hooks/usePost";
@@ -55,6 +56,15 @@ export function PostPage({ slug }: { slug: string }) {
                 <p className="m-0">{format(new Date(post.updatedAt), "yyyy년 MM월 dd일 HH:mm")}</p>
               </div>
             </div>
+          </div>
+
+          <div className="relative z-10 mt-5">
+            <ReactionButton
+              targetType="post"
+              targetId={post.id}
+              reactions={post.reactions}
+              canReact={session?.user.role === "admin"}
+            />
           </div>
         </section>
 

--- a/src/components/post/PostComment.tsx
+++ b/src/components/post/PostComment.tsx
@@ -3,7 +3,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { format } from "date-fns";
 import DOMPurify from "isomorphic-dompurify";
-import { ImageIcon, Repeat2Icon, ReplyIcon, XIcon } from "lucide-react";
+import { ImageIcon, ReplyIcon, XIcon } from "lucide-react";
 import Link from "next/link";
 import { useRef, useState } from "react";
 import { useForm } from "react-hook-form";

--- a/src/components/post/PostComment.tsx
+++ b/src/components/post/PostComment.tsx
@@ -3,12 +3,13 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { format } from "date-fns";
 import DOMPurify from "isomorphic-dompurify";
-import { HeartIcon, ImageIcon, Repeat2Icon, ReplyIcon, XIcon } from "lucide-react";
+import { ImageIcon, Repeat2Icon, ReplyIcon, XIcon } from "lucide-react";
 import Link from "next/link";
 import { useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 
+import { ReactionButton } from "./ReactionButton";
 import { Button } from "~/components/ui/button";
 import { Form, FormControl, FormField, FormItem, FormMessage } from "~/components/ui/form";
 import { Textarea } from "~/components/ui/textarea";
@@ -104,13 +105,23 @@ function CommentItem({
             })}
         </div>
 
-        {session?.user.role === "admin" && (
-          <div className="mt-2 flex items-center gap-4">
-            <ReplyButton comment={comment} onToggle={() => setShowReplyEditor(!showReplyEditor)} />
-            <RenoteButton />
-            <LikeButton />
-          </div>
-        )}
+        <div className="mt-2 flex items-center gap-4">
+          {session?.user.role === "admin" && (
+            <>
+              <ReplyButton
+                comment={comment}
+                onToggle={() => setShowReplyEditor(!showReplyEditor)}
+              />
+              <RenoteButton />
+            </>
+          )}
+          <ReactionButton
+            targetType="comment"
+            targetId={comment.id}
+            reactions={comment.reactions}
+            canReact={session?.user.role === "admin"}
+          />
+        </div>
 
         {showReplyEditor && (
           <div className="mt-4">
@@ -158,14 +169,6 @@ function RenoteButton() {
   return (
     <button className="flex cursor-pointer items-center gap-1 text-(--ink-soft) hover:text-(--accent-paper)">
       <Repeat2Icon className="size-4" />
-    </button>
-  );
-}
-
-function LikeButton() {
-  return (
-    <button className="flex cursor-pointer items-center gap-1 text-(--ink-soft) hover:text-(--accent-paper)">
-      <HeartIcon className="size-4" />
     </button>
   );
 }

--- a/src/components/post/ReactionButton.tsx
+++ b/src/components/post/ReactionButton.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { HeartIcon } from "lucide-react";
+import { useState } from "react";
+
+import { Popover, PopoverContent, PopoverTrigger } from "~/components/ui/popover";
+import { useCreateReaction } from "~/hooks/useCreateReaction";
+
+type Reaction = {
+  id: string;
+  content: string;
+  emojiName: string | null;
+  emojiIconUrl: string | null;
+  emojiIconMediaType: string | null;
+};
+
+const PINNED_EMOJIS = ["❤️", "😂", "👍", "🎉", "🔥", "😮", "😢", "🙏"];
+const EMOJIS = ["✨", "🥰", "👏", "🤔", "👀", "💯", "🌸", "🍀", "☕", "🚀", "🫠", "🙌"];
+
+export function ReactionButton({
+  targetType,
+  targetId,
+  reactions,
+  canReact = true,
+}: {
+  targetType: "post" | "comment";
+  targetId: string;
+  reactions: Reaction[];
+  canReact?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const { mutate: createReaction, status } = useCreateReaction();
+  const groupedReactions = groupReactions(reactions);
+  const isPending = status === "pending";
+
+  if (!canReact && groupedReactions.length === 0) return null;
+
+  const handleSelect = (content: string) => {
+    createReaction(
+      { targetType, targetId, content },
+      {
+        onSuccess: () => setOpen(false),
+      },
+    );
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      {canReact && (
+        <Popover open={open} onOpenChange={setOpen}>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              disabled={isPending}
+              className="flex cursor-pointer items-center gap-1 text-(--ink-soft) hover:text-(--accent-paper) disabled:cursor-not-allowed disabled:opacity-50"
+              aria-label="이모지 리액션 보내기"
+            >
+              <HeartIcon className="size-4" />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent
+            align="start"
+            className="w-72 rounded-2xl border-2 border-(--line) bg-(--paper) p-3"
+          >
+            <div className="grid gap-3">
+              <section>
+                <p className="muted mb-2 text-xs font-semibold">자주 쓰는 이모지</p>
+                <EmojiGrid emojis={PINNED_EMOJIS} onSelect={handleSelect} disabled={isPending} />
+              </section>
+              <section>
+                <p className="muted mb-2 text-xs font-semibold">이모지</p>
+                <EmojiGrid emojis={EMOJIS} onSelect={handleSelect} disabled={isPending} />
+              </section>
+              <p className="muted text-xs">하트는 ActivityPub Like로 전송됩니다.</p>
+            </div>
+          </PopoverContent>
+        </Popover>
+      )}
+
+      {groupedReactions.map((reaction) => (
+        <span
+          key={reaction.content}
+          className="inline-flex items-center gap-1 rounded-full border border-(--line) bg-(--paper-note) px-2 py-0.5 text-sm"
+        >
+          {reaction.iconUrl ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={reaction.iconUrl} alt={reaction.label} className="size-4 object-contain" />
+          ) : (
+            <span>{reaction.label}</span>
+          )}
+          <span>{reaction.count}</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function EmojiGrid({
+  emojis,
+  onSelect,
+  disabled,
+}: {
+  emojis: string[];
+  onSelect: (emoji: string) => void;
+  disabled: boolean;
+}) {
+  return (
+    <div className="grid grid-cols-8 gap-1">
+      {emojis.map((emoji) => (
+        <button
+          key={emoji}
+          type="button"
+          disabled={disabled}
+          onClick={() => onSelect(emoji)}
+          className="flex size-8 cursor-pointer items-center justify-center rounded-xl text-lg hover:bg-(--paper-note) disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {emoji}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function groupReactions(reactions: Reaction[]) {
+  const groups = new Map<
+    string,
+    { content: string; label: string; iconUrl: string | null; count: number }
+  >();
+
+  for (const reaction of reactions) {
+    const existing = groups.get(reaction.content);
+
+    if (existing) {
+      existing.count += 1;
+      continue;
+    }
+
+    groups.set(reaction.content, {
+      content: reaction.content,
+      label: reaction.emojiName ?? reaction.content,
+      iconUrl: reaction.emojiIconUrl,
+      count: 1,
+    });
+  }
+
+  return [...groups.values()];
+}

--- a/src/components/post/ReactionButton.tsx
+++ b/src/components/post/ReactionButton.tsx
@@ -4,7 +4,7 @@ import { HeartIcon } from "lucide-react";
 import { useState } from "react";
 
 import { Popover, PopoverContent, PopoverTrigger } from "~/components/ui/popover";
-import { useCreateReaction } from "~/hooks/useCreateReaction";
+import { useCreateReaction, useDeleteReaction } from "~/hooks/useCreateReaction";
 
 type Reaction = {
   id: string;
@@ -30,8 +30,9 @@ export function ReactionButton({
 }) {
   const [open, setOpen] = useState(false);
   const { mutate: createReaction, status } = useCreateReaction();
+  const { mutate: deleteReaction, status: deleteStatus } = useDeleteReaction();
   const groupedReactions = groupReactions(reactions);
-  const isPending = status === "pending";
+  const isPending = status === "pending" || deleteStatus === "pending";
 
   if (!canReact && groupedReactions.length === 0) return null;
 
@@ -42,6 +43,11 @@ export function ReactionButton({
         onSuccess: () => setOpen(false),
       },
     );
+  };
+
+  const handleDelete = (content: string) => {
+    if (!canReact || isPending) return;
+    deleteReaction({ targetType, targetId, content });
   };
 
   return (
@@ -78,9 +84,13 @@ export function ReactionButton({
       )}
 
       {groupedReactions.map((reaction) => (
-        <span
+        <button
           key={reaction.content}
-          className="inline-flex items-center gap-1 rounded-full border border-(--line) bg-(--paper-note) px-2 py-0.5 text-sm"
+          type="button"
+          disabled={!canReact || isPending}
+          onClick={() => handleDelete(reaction.content)}
+          className="inline-flex items-center gap-1 rounded-full border border-(--line) bg-(--paper-note) px-2 py-0.5 text-sm enabled:cursor-pointer enabled:hover:bg-(--accent-paper)/10 disabled:cursor-default"
+          aria-label={`${reaction.label} 리액션 취소`}
         >
           {reaction.iconUrl ? (
             // eslint-disable-next-line @next/next/no-img-element
@@ -89,7 +99,7 @@ export function ReactionButton({
             <span>{reaction.label}</span>
           )}
           <span>{reaction.count}</span>
-        </span>
+        </button>
       ))}
     </div>
   );

--- a/src/federation.ts
+++ b/src/federation.ts
@@ -1,4 +1,14 @@
-import { Create, Delete, Follow, Note, Undo, Update, createFederation } from "@fedify/fedify";
+import {
+  Create,
+  Delete,
+  EmojiReact,
+  Follow,
+  Like,
+  Note,
+  Undo,
+  Update,
+  createFederation,
+} from "@fedify/fedify";
 import { RedisKvStore, RedisMessageQueue } from "@fedify/redis";
 import { Redis } from "ioredis";
 
@@ -12,6 +22,7 @@ import { dispatchOutbox } from "./federation/dispatchOutbox";
 import { handleCreate } from "./federation/handleCreate";
 import { handleDelete } from "./federation/handleDelete";
 import { handleFollow } from "./federation/handleFollow";
+import { handleReaction } from "./federation/handleReaction";
 import { handleUndo } from "./federation/handleUndo";
 import { handleUpdate } from "./federation/handleUpdate";
 import { logInboxActivity } from "./federation/logInboxActivity";
@@ -42,7 +53,9 @@ federation
   .on(Undo, logInboxActivity(handleUndo))
   .on(Create, logInboxActivity(handleCreate))
   .on(Delete, logInboxActivity(handleDelete))
-  .on(Update, logInboxActivity(handleUpdate));
+  .on(Update, logInboxActivity(handleUpdate))
+  .on(Like, logInboxActivity(handleReaction))
+  .on(EmojiReact, logInboxActivity(handleReaction));
 
 federation
   .setFollowersDispatcher("/users/{identifier}/followers", dispatchFollowers)

--- a/src/federation/handleReaction.ts
+++ b/src/federation/handleReaction.ts
@@ -1,0 +1,90 @@
+import { Emoji, EmojiReact, isActor, Like } from "@fedify/fedify";
+
+import { log } from "./log";
+import { prisma } from "~/lib/prisma";
+import { isUniqueConstraintError, upsertActor } from "~/lib/utils-federation";
+
+import type { InboxActivityStatus } from "./logInboxActivity";
+import type { InboxContext } from "@fedify/fedify";
+
+type ReactionActivity = Like | EmojiReact;
+
+const LIKE_CONTENT = "❤️";
+
+export async function handleReaction(
+  _ctx: InboxContext<unknown>,
+  reaction: ReactionActivity,
+): Promise<InboxActivityStatus> {
+  log(
+    `Received ${reaction instanceof Like ? "Like" : "EmojiReact"} activity: ${reaction.id?.href}`,
+  );
+
+  if (reaction.actorId == null || reaction.objectId == null || reaction.id == null) {
+    return "ignored";
+  }
+
+  const actor = await reaction.getActor();
+  if (!isActor(actor) || actor.id?.href !== reaction.actorId.href) return "ignored";
+
+  const targetUri = reaction.objectId.href;
+  const [post, comment] = await Promise.all([
+    prisma.posts.findFirst({ where: { uri: targetUri }, select: { id: true } }),
+    prisma.comment.findFirst({ where: { uri: targetUri }, select: { id: true } }),
+  ]);
+
+  if (!post && !comment) {
+    log(`Reaction target not found: ${targetUri}`);
+    return "ignored";
+  }
+
+  const actorRecord = await upsertActor(actor);
+  if (!actorRecord) return "ignored";
+
+  const customEmoji = await getCustomEmoji(reaction);
+  const content = reaction.content?.toString() || LIKE_CONTENT;
+
+  try {
+    await prisma.reaction.create({
+      data: {
+        uri: reaction.id.href,
+        activityType: reaction instanceof Like ? "Like" : "EmojiReact",
+        content,
+        actorId: actorRecord.id,
+        postId: post?.id,
+        commentId: comment?.id,
+        targetUri,
+        to: reaction.toIds.map((to) => to.href),
+        cc: reaction.ccIds.map((cc) => cc.href),
+        emojiName: customEmoji?.name,
+        emojiIconUrl: customEmoji?.iconUrl,
+        emojiIconMediaType: customEmoji?.iconMediaType,
+      },
+    });
+  } catch (error) {
+    if (isUniqueConstraintError(error)) {
+      log(`Reaction already exists, skipping duplicate: ${reaction.id.href}`);
+      return "ignored";
+    }
+    throw error;
+  }
+
+  log(`Saved reaction: ${reaction.id.href}`);
+  return "handled";
+}
+
+async function getCustomEmoji(reaction: ReactionActivity) {
+  for await (const tag of reaction.getTags()) {
+    if (!(tag instanceof Emoji)) continue;
+
+    const icon = await tag.getIcon();
+    const iconUrl = icon?.url?.href?.toString() ?? null;
+
+    return {
+      name: tag.name?.toString() ?? reaction.content?.toString(),
+      iconUrl,
+      iconMediaType: icon?.mediaType ?? null,
+    };
+  }
+
+  return null;
+}

--- a/src/federation/handleUndo.ts
+++ b/src/federation/handleUndo.ts
@@ -1,4 +1,4 @@
-import { Follow } from "@fedify/fedify";
+import { EmojiReact, Follow, Like } from "@fedify/fedify";
 
 import { log } from "./log";
 import { prisma } from "~/lib/prisma";
@@ -13,7 +13,33 @@ export async function handleUndo(
   log(`Received Undo activity: ${undo.id?.href}`);
 
   const object = await undo.getObject();
-  if (!(object instanceof Follow)) return "ignored";
+
+  if (object instanceof Like || object instanceof EmojiReact) {
+    if (undo.actorId == null || object.id == null) return "ignored";
+
+    await prisma.reaction.deleteMany({
+      where: {
+        uri: object.id.href,
+        actor: { uri: undo.actorId.href },
+      },
+    });
+
+    return "handled";
+  }
+
+  if (!(object instanceof Follow)) {
+    if (undo.objectId == null || undo.actorId == null) return "ignored";
+
+    const result = await prisma.reaction.deleteMany({
+      where: {
+        uri: undo.objectId.href,
+        actor: { uri: undo.actorId.href },
+      },
+    });
+
+    return result.count > 0 ? "handled" : "ignored";
+  }
+
   if (undo.actorId == null || object.objectId == null) return "ignored";
 
   const parsed = ctx.parseUri(object.objectId);

--- a/src/hooks/useCreateReaction.ts
+++ b/src/hooks/useCreateReaction.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+import { createReaction } from "~/lib/actions/post";
+
+export function useCreateReaction() {
+  const router = useRouter();
+
+  return useMutation({
+    mutationFn: (data: Parameters<typeof createReaction>[0]) => createReaction(data),
+    onSuccess: () => {
+      toast.success("리액션을 보냈습니다.");
+      router.refresh();
+    },
+    onError: (error) => {
+      console.error("Failed to create reaction:", error);
+      toast.error("리액션 전송에 실패했습니다. 다시 시도해주세요.");
+    },
+  });
+}

--- a/src/hooks/useCreateReaction.ts
+++ b/src/hooks/useCreateReaction.ts
@@ -4,7 +4,7 @@ import { useMutation } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 
-import { createReaction } from "~/lib/actions/post";
+import { createReaction, deleteReaction } from "~/lib/actions/post";
 
 export function useCreateReaction() {
   const router = useRouter();
@@ -18,6 +18,22 @@ export function useCreateReaction() {
     onError: (error) => {
       console.error("Failed to create reaction:", error);
       toast.error("리액션 전송에 실패했습니다. 다시 시도해주세요.");
+    },
+  });
+}
+
+export function useDeleteReaction() {
+  const router = useRouter();
+
+  return useMutation({
+    mutationFn: (data: Parameters<typeof deleteReaction>[0]) => deleteReaction(data),
+    onSuccess: () => {
+      toast.success("리액션을 취소했습니다.");
+      router.refresh();
+    },
+    onError: (error) => {
+      console.error("Failed to delete reaction:", error);
+      toast.error("리액션 취소에 실패했습니다. 다시 시도해주세요.");
     },
   });
 }

--- a/src/lib/actions/post.ts
+++ b/src/lib/actions/post.ts
@@ -120,3 +120,13 @@ export async function createReaction(
 
   return await postService.createReaction(data);
 }
+
+export async function deleteReaction(
+  data: Parameters<typeof PostService.prototype.deleteReaction>[0],
+) {
+  const session = await getValidAdminSession();
+
+  const postService = new PostService(session.user.id);
+
+  return await postService.deleteReaction(data);
+}

--- a/src/lib/actions/post.ts
+++ b/src/lib/actions/post.ts
@@ -110,3 +110,13 @@ export async function createComment(data: {
     images: uploadedImages.length > 0 ? uploadedImages : undefined,
   });
 }
+
+export async function createReaction(
+  data: Parameters<typeof PostService.prototype.createReaction>[0],
+) {
+  const session = await getValidAdminSession();
+
+  const postService = new PostService(session.user.id);
+
+  return await postService.createReaction(data);
+}

--- a/src/lib/models/post.ts
+++ b/src/lib/models/post.ts
@@ -743,3 +743,65 @@ export async function createReaction(data: {
 
   return reaction;
 }
+
+export async function deleteReaction(data: {
+  targetType: "post" | "comment";
+  targetId: string;
+  content: string;
+}) {
+  const mainActor = await prisma.mainActor.findFirst({
+    include: { actor: true },
+  });
+
+  if (!mainActor) {
+    throw new Error("Main actor is not defined");
+  }
+
+  const reaction = await prisma.reaction.findFirst({
+    where: {
+      actorId: mainActor.actor.id,
+      content: data.content,
+      ...(data.targetType === "post" ? { postId: data.targetId } : { commentId: data.targetId }),
+    },
+  });
+
+  if (!reaction) return null;
+
+  const ctx = federation.createContext(new Request(process.env.PUBLIC_URL!), undefined);
+  const target =
+    data.targetType === "post"
+      ? await prisma.posts.findUniqueOrThrow({
+          where: { id: data.targetId },
+          select: { actor: true },
+        })
+      : await prisma.comment.findUniqueOrThrow({
+          where: { id: data.targetId },
+          select: { actor: true },
+        });
+  const targetActor = target.actor;
+  const directRecipient =
+    targetActor.uri === mainActor.actor.uri
+      ? null
+      : {
+          id: new URL(targetActor.uri),
+          inboxId: new URL(targetActor.inboxUrl),
+          endpoints: targetActor.sharedInboxUrl
+            ? { sharedInbox: new URL(targetActor.sharedInboxUrl) }
+            : null,
+        };
+  const undo = new Undo({
+    id: new URL(`${process.env.PUBLIC_URL}/activities/${crypto.randomUUID()}`),
+    actor: new URL(mainActor.actor.uri),
+    object: new URL(reaction.uri),
+    tos: reaction.to.map((uri) => new URL(uri)),
+    ccs: reaction.cc.map((uri) => new URL(uri)),
+  });
+
+  await ctx.sendActivity({ identifier: mainActor.actor.username }, "followers", undo);
+
+  if (directRecipient) {
+    await ctx.sendActivity({ identifier: mainActor.actor.username }, [directRecipient], undo);
+  }
+
+  return await prisma.reaction.delete({ where: { id: reaction.id } });
+}

--- a/src/lib/models/post.ts
+++ b/src/lib/models/post.ts
@@ -4,10 +4,12 @@ import {
   Delete,
   Document,
   isActor,
+  Like,
   Mention,
   Note,
   PUBLIC_COLLECTION,
   Recipient,
+  Undo,
   Update,
 } from "@fedify/fedify";
 import { Temporal } from "@js-temporal/polyfill";
@@ -22,6 +24,7 @@ import { prisma } from "~/lib/prisma";
 
 const commentInclude = {
   attachment: true,
+  reactions: true,
   actor: {
     include: {
       avatar: true,
@@ -284,6 +287,7 @@ export async function getPostBySlug(slug: string, userId?: string) {
       },
       banner: true,
       category: true,
+      reactions: true,
     },
   });
 
@@ -623,4 +627,119 @@ export async function createComment(
   }
 
   return comment;
+}
+
+export async function createReaction(data: {
+  targetType: "post" | "comment";
+  targetId: string;
+  content: string;
+}) {
+  const mainActor = await prisma.mainActor.findFirst({
+    include: { actor: true },
+  });
+
+  if (!mainActor) {
+    throw new Error("Main actor is not defined");
+  }
+
+  const ctx = federation.createContext(new Request(process.env.PUBLIC_URL!), undefined);
+  const target =
+    data.targetType === "post"
+      ? await prisma.posts.findUniqueOrThrow({
+          where: { id: data.targetId },
+          select: {
+            id: true,
+            uri: true,
+            actor: true,
+          },
+        })
+      : await prisma.comment.findUniqueOrThrow({
+          where: { id: data.targetId },
+          select: {
+            id: true,
+            uri: true,
+            actor: true,
+            post: {
+              select: {
+                actor: true,
+              },
+            },
+          },
+        });
+
+  const existingReaction = await prisma.reaction.findFirst({
+    where: {
+      actorId: mainActor.actor.id,
+      ...(data.targetType === "post" ? { postId: data.targetId } : { commentId: data.targetId }),
+    },
+  });
+
+  if (existingReaction?.content === data.content) return existingReaction;
+
+  const reactionId = crypto.randomUUID();
+  const reactionUri = `${process.env.PUBLIC_URL}/activities/${reactionId}`;
+  const followersUri = ctx.getFollowersUri(mainActor.actor.username).href;
+  const targetActor = data.targetType === "post" ? target.actor : target.actor;
+  const to = [targetActor.uri];
+  const cc = [followersUri];
+
+  const directRecipient =
+    targetActor.uri === mainActor.actor.uri
+      ? null
+      : {
+          id: new URL(targetActor.uri),
+          inboxId: new URL(targetActor.inboxUrl),
+          endpoints: targetActor.sharedInboxUrl
+            ? { sharedInbox: new URL(targetActor.sharedInboxUrl) }
+            : null,
+        };
+
+  if (existingReaction) {
+    const undo = new Undo({
+      id: new URL(`${process.env.PUBLIC_URL}/activities/${crypto.randomUUID()}`),
+      actor: new URL(mainActor.actor.uri),
+      object: new URL(existingReaction.uri),
+      tos: existingReaction.to.map((uri) => new URL(uri)),
+      ccs: existingReaction.cc.map((uri) => new URL(uri)),
+    });
+
+    await ctx.sendActivity({ identifier: mainActor.actor.username }, "followers", undo);
+
+    if (directRecipient) {
+      await ctx.sendActivity({ identifier: mainActor.actor.username }, [directRecipient], undo);
+    }
+
+    await prisma.reaction.delete({ where: { id: existingReaction.id } });
+  }
+
+  const reaction = await prisma.reaction.create({
+    data: {
+      uri: reactionUri,
+      activityType: "Like",
+      content: data.content,
+      actorId: mainActor.actor.id,
+      postId: data.targetType === "post" ? data.targetId : undefined,
+      commentId: data.targetType === "comment" ? data.targetId : undefined,
+      targetUri: target.uri,
+      to,
+      cc,
+    },
+  });
+
+  const activity = new Like({
+    id: new URL(reactionUri),
+    actor: new URL(mainActor.actor.uri),
+    object: new URL(target.uri),
+    content: data.content === "❤️" ? undefined : data.content,
+    tos: to.map((uri) => new URL(uri)),
+    ccs: cc.map((uri) => new URL(uri)),
+  });
+
+  await ctx.sendActivity({ identifier: mainActor.actor.username }, "followers", activity);
+
+  if (directRecipient) {
+    await ctx.sendActivity({ identifier: mainActor.actor.username }, [directRecipient], activity);
+  }
+
+  return reaction;
 }

--- a/src/lib/services/post.ts
+++ b/src/lib/services/post.ts
@@ -1,6 +1,7 @@
 import {
   createComment,
   createPost,
+  createReaction,
   deletePost,
   getCategories,
   getCommentsBySlug,
@@ -108,5 +109,10 @@ export class PostService {
 
     const comment = await createComment(mainActor.actor.id, data);
     return comment;
+  }
+
+  @requireUserId
+  async createReaction(data: Parameters<typeof createReaction>[0]) {
+    return await createReaction(data);
   }
 }

--- a/src/lib/services/post.ts
+++ b/src/lib/services/post.ts
@@ -2,6 +2,7 @@ import {
   createComment,
   createPost,
   createReaction,
+  deleteReaction,
   deletePost,
   getCategories,
   getCommentsBySlug,
@@ -114,5 +115,10 @@ export class PostService {
   @requireUserId
   async createReaction(data: Parameters<typeof createReaction>[0]) {
     return await createReaction(data);
+  }
+
+  @requireUserId
+  async deleteReaction(data: Parameters<typeof deleteReaction>[0]) {
+    return await deleteReaction(data);
   }
 }

--- a/src/prisma/migrations/20260702000000_add_reactions/migration.sql
+++ b/src/prisma/migrations/20260702000000_add_reactions/migration.sql
@@ -1,0 +1,44 @@
+-- CreateTable
+CREATE TABLE "reactions" (
+    "id" TEXT NOT NULL,
+    "uri" TEXT NOT NULL,
+    "activityType" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "actorId" TEXT NOT NULL,
+    "postId" TEXT,
+    "commentId" TEXT,
+    "targetUri" TEXT NOT NULL,
+    "to" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "cc" TEXT[] DEFAULT ARRAY[]::TEXT[],
+    "emojiName" TEXT,
+    "emojiIconUrl" TEXT,
+    "emojiIconMediaType" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "reactions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "reactions_uri_key" ON "reactions"("uri");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "reactions_actorId_postId_content_key" ON "reactions"("actorId", "postId", "content");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "reactions_actorId_commentId_content_key" ON "reactions"("actorId", "commentId", "content");
+
+-- CreateIndex
+CREATE INDEX "reactions_targetUri_idx" ON "reactions"("targetUri");
+
+-- CreateIndex
+CREATE INDEX "reactions_activityType_idx" ON "reactions"("activityType");
+
+-- AddForeignKey
+ALTER TABLE "reactions" ADD CONSTRAINT "reactions_actorId_fkey" FOREIGN KEY ("actorId") REFERENCES "actor"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "reactions" ADD CONSTRAINT "reactions_postId_fkey" FOREIGN KEY ("postId") REFERENCES "posts"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "reactions" ADD CONSTRAINT "reactions_commentId_fkey" FOREIGN KEY ("commentId") REFERENCES "comments"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -34,6 +34,7 @@ model Actor {
   mainActor      MainActor?
   posts          Posts[]
   comments       Comment[]
+  reactions      Reaction[]
   avatar         Image?     @relation("Avatar", fields: [avatarId], references: [id])
   avatarId       String?    @unique
   banner         Image?     @relation("Banner", fields: [bannerId], references: [id])
@@ -107,6 +108,7 @@ model Posts {
   banner      Image?    @relation("PostBanner", fields: [bannerId], references: [id])
   bannerId    String?   @unique
   comments    Comment[]
+  reactions   Reaction[]
 
   @@map("posts")
 }
@@ -233,10 +235,38 @@ model Comment {
   cc         String[]     @default([])
   mentions   Json[]       @default([])
   attachment Attachment[]
+  reactions  Reaction[]
   createdAt  DateTime     @default(now())
   updatedAt  DateTime     @default(now()) @updatedAt
 
   @@map("comments")
+}
+
+model Reaction {
+  id                 String   @id @default(uuid(7))
+  uri                String   @unique
+  activityType       String
+  content            String
+  actorId            String
+  actor              Actor    @relation(fields: [actorId], references: [id], onDelete: Cascade)
+  postId             String?
+  post               Posts?   @relation(fields: [postId], references: [id], onDelete: Cascade)
+  commentId          String?
+  comment            Comment? @relation(fields: [commentId], references: [id], onDelete: Cascade)
+  targetUri          String
+  to                 String[] @default([])
+  cc                 String[] @default([])
+  emojiName          String?
+  emojiIconUrl       String?
+  emojiIconMediaType String?
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @default(now()) @updatedAt
+
+  @@unique([actorId, postId, content])
+  @@unique([actorId, commentId, content])
+  @@index([targetUri])
+  @@index([activityType])
+  @@map("reactions")
 }
 
 model Attachment {

--- a/src/tests/federation.handleReaction.test.ts
+++ b/src/tests/federation.handleReaction.test.ts
@@ -1,0 +1,88 @@
+import { Emoji, EmojiReact, Image, Like } from "@fedify/fedify";
+
+import { createCtx, createRemoteActor, mocks } from "./federation.helpers";
+
+const { handleReaction } = await import("../federation/handleReaction");
+
+describe("handleReaction", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("saves a remote Like as a heart reaction", async () => {
+    const actor = createRemoteActor();
+    const like = new Like({
+      id: new URL("https://remote.test/activities/like-1"),
+      actor: actor.id,
+      object: new URL("https://example.com/post/hello"),
+      tos: [new URL("https://example.com/users/alice")],
+    });
+    vi.spyOn(like, "getActor").mockResolvedValue(actor);
+    mocks.prisma.posts.findFirst.mockResolvedValueOnce({ id: "post-1" });
+    mocks.prisma.comment.findFirst.mockResolvedValueOnce(null);
+    mocks.upsertActor.mockResolvedValueOnce({ id: "remote-actor" });
+
+    await expect(handleReaction(createCtx(), like)).resolves.toBe("handled");
+
+    expect(mocks.prisma.reaction.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        uri: "https://remote.test/activities/like-1",
+        activityType: "Like",
+        content: "❤️",
+        actorId: "remote-actor",
+        postId: "post-1",
+        targetUri: "https://example.com/post/hello",
+      }),
+    });
+  });
+
+  it("saves a remote EmojiReact with custom emoji metadata", async () => {
+    const actor = createRemoteActor();
+    const emojiReact = new EmojiReact({
+      id: new URL("https://remote.test/activities/react-1"),
+      actor: actor.id,
+      object: new URL("https://example.com/post/hello"),
+      content: ":blobcat:",
+      tags: [
+        new Emoji({
+          name: ":blobcat:",
+          icon: new Image({
+            url: new URL("https://remote.test/blobcat.png"),
+            mediaType: "image/png",
+          }),
+        }),
+      ],
+    });
+    vi.spyOn(emojiReact, "getActor").mockResolvedValue(actor);
+    mocks.prisma.posts.findFirst.mockResolvedValueOnce({ id: "post-1" });
+    mocks.prisma.comment.findFirst.mockResolvedValueOnce(null);
+    mocks.upsertActor.mockResolvedValueOnce({ id: "remote-actor" });
+
+    await expect(handleReaction(createCtx(), emojiReact)).resolves.toBe("handled");
+
+    expect(mocks.prisma.reaction.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        activityType: "EmojiReact",
+        content: ":blobcat:",
+        emojiName: ":blobcat:",
+        emojiIconUrl: "https://remote.test/blobcat.png",
+        emojiIconMediaType: "image/png",
+      }),
+    });
+  });
+
+  it("ignores duplicate reactions", async () => {
+    const actor = createRemoteActor();
+    const emojiReact = new EmojiReact({
+      id: new URL("https://remote.test/activities/react-1"),
+      actor: actor.id,
+      object: new URL("https://example.com/post/hello"),
+      content: "🔥",
+    });
+    vi.spyOn(emojiReact, "getActor").mockResolvedValue(actor);
+    mocks.prisma.posts.findFirst.mockResolvedValueOnce({ id: "post-1" });
+    mocks.prisma.comment.findFirst.mockResolvedValueOnce(null);
+    mocks.upsertActor.mockResolvedValueOnce({ id: "remote-actor" });
+    mocks.prisma.reaction.create.mockRejectedValueOnce({ code: "P2002" });
+
+    await expect(handleReaction(createCtx(), emojiReact)).resolves.toBe("ignored");
+  });
+});

--- a/src/tests/federation.handleUndo.test.ts
+++ b/src/tests/federation.handleUndo.test.ts
@@ -1,4 +1,4 @@
-import { Follow } from "@fedify/fedify";
+import { Follow, Like } from "@fedify/fedify";
 
 import { createCtx, mocks } from "./federation.helpers";
 
@@ -28,6 +28,27 @@ describe("handleUndo", () => {
 
     expect(mocks.prisma.follows.deleteMany).toHaveBeenCalledWith({
       where: { followingId: "local-actor", followerId: "remote-actor" },
+    });
+  });
+
+  it("removes a reaction on Undo(Like)", async () => {
+    const like = new Like({
+      id: new URL("https://remote.test/activities/like-1"),
+      actor: new URL("https://remote.test/users/bob"),
+      object: new URL("https://example.com/post/hello"),
+    });
+    const undo = {
+      actorId: new URL("https://remote.test/users/bob"),
+      getObject: vi.fn(async () => like),
+    };
+
+    await handleUndo(createCtx(), undo as Pick<Undo, "actorId" | "getObject"> as Undo);
+
+    expect(mocks.prisma.reaction.deleteMany).toHaveBeenCalledWith({
+      where: {
+        uri: "https://remote.test/activities/like-1",
+        actor: { uri: "https://remote.test/users/bob" },
+      },
     });
   });
 });

--- a/src/tests/federation.helpers.ts
+++ b/src/tests/federation.helpers.ts
@@ -12,6 +12,7 @@ vi.hoisted(() => {
       inboxActivityLog: { create: vi.fn(), update: vi.fn(), findMany: vi.fn(), count: vi.fn() },
       posts: { count: vi.fn(), findFirst: vi.fn(), findMany: vi.fn() },
       comment: { create: vi.fn(), delete: vi.fn(), findFirst: vi.fn(), update: vi.fn() },
+      reaction: { create: vi.fn(), deleteMany: vi.fn(), findFirst: vi.fn() },
     },
     upsertActor: vi.fn(),
     getTagFromNote: vi.fn(),
@@ -44,6 +45,11 @@ type FederationTestMocks = {
       delete: ReturnType<typeof vi.fn>;
       findFirst: ReturnType<typeof vi.fn>;
       update: ReturnType<typeof vi.fn>;
+    };
+    reaction: {
+      create: ReturnType<typeof vi.fn>;
+      deleteMany: ReturnType<typeof vi.fn>;
+      findFirst: ReturnType<typeof vi.fn>;
     };
   };
   upsertActor: ReturnType<typeof vi.fn>;

--- a/src/tests/post.federation.test.ts
+++ b/src/tests/post.federation.test.ts
@@ -1,4 +1,4 @@
-import { Note } from "@fedify/fedify";
+import { Like, Note, Undo } from "@fedify/fedify";
 
 const mocks = vi.hoisted(() => ({
   ctx: {
@@ -21,7 +21,13 @@ const mocks = vi.hoisted(() => ({
       create: vi.fn(),
       findMany: vi.fn(),
       findUnique: vi.fn(),
+      findUniqueOrThrow: vi.fn(),
       update: vi.fn(),
+    },
+    reaction: {
+      create: vi.fn(),
+      delete: vi.fn(),
+      findFirst: vi.fn(),
     },
   },
 }));
@@ -53,6 +59,8 @@ function localMainActor() {
       id: "local-actor-id",
       username: "alice",
       uri: "https://example.com/users/alice",
+      inboxUrl: "https://example.com/users/alice/inbox",
+      sharedInboxUrl: null,
     },
   };
 }
@@ -163,6 +171,7 @@ describe("post model federation publishing", () => {
       where: { postId: "post-1" },
       include: {
         attachment: true,
+        reactions: true,
         actor: {
           include: {
             avatar: true,
@@ -221,6 +230,71 @@ describe("post model federation publishing", () => {
     const comments = await postModel.getCommentsBySlug("hello", { includeFollowersOnly: true });
 
     expect(comments.map((comment) => comment.id)).toEqual(["comment-1"]);
+  });
+
+  it("sends a heart reaction as Like", async () => {
+    mocks.prisma.mainActor.findFirst.mockResolvedValueOnce(localMainActor());
+    mocks.prisma.posts.findUniqueOrThrow.mockResolvedValueOnce({
+      id: "post-1",
+      uri: "https://example.com/post/hello",
+      actor: localMainActor().actor,
+    });
+    mocks.prisma.reaction.findFirst.mockResolvedValueOnce(null);
+    mocks.prisma.reaction.create.mockResolvedValueOnce({ id: "reaction-1", content: "❤️" });
+
+    await postModel.createReaction({ targetType: "post", targetId: "post-1", content: "❤️" });
+
+    expect(mocks.prisma.reaction.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ activityType: "Like", content: "❤️" }),
+    });
+    expect(mocks.ctx.sendActivity.mock.calls[0][2]).toBeInstanceOf(Like);
+  });
+
+  it("sends a non-heart reaction as Like with content", async () => {
+    mocks.prisma.mainActor.findFirst.mockResolvedValueOnce(localMainActor());
+    mocks.prisma.posts.findUniqueOrThrow.mockResolvedValueOnce({
+      id: "post-1",
+      uri: "https://example.com/post/hello",
+      actor: localMainActor().actor,
+    });
+    mocks.prisma.reaction.findFirst.mockResolvedValueOnce(null);
+    mocks.prisma.reaction.create.mockResolvedValueOnce({ id: "reaction-1", content: "🔥" });
+
+    await postModel.createReaction({ targetType: "post", targetId: "post-1", content: "🔥" });
+
+    expect(mocks.prisma.reaction.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({ activityType: "Like", content: "🔥" }),
+    });
+    expect(mocks.ctx.sendActivity.mock.calls[0][2]).toBeInstanceOf(Like);
+    expect(mocks.ctx.sendActivity.mock.calls[0][2].content?.toString()).toBe("🔥");
+  });
+
+  it("undoes and replaces an existing reaction on the same post", async () => {
+    mocks.prisma.mainActor.findFirst.mockResolvedValueOnce(localMainActor());
+    mocks.prisma.posts.findUniqueOrThrow.mockResolvedValueOnce({
+      id: "post-1",
+      uri: "https://example.com/post/hello",
+      actor: {
+        ...localMainActor().actor,
+        uri: "https://remote.test/users/bob",
+        inboxUrl: "https://remote.test/users/bob/inbox",
+        sharedInboxUrl: "https://remote.test/inbox",
+      },
+    });
+    mocks.prisma.reaction.findFirst.mockResolvedValueOnce({
+      id: "reaction-old",
+      uri: "https://example.com/activities/old",
+      content: "😂",
+      to: ["https://remote.test/users/bob"],
+      cc: ["https://example.com/users/alice/followers"],
+    });
+    mocks.prisma.reaction.create.mockResolvedValueOnce({ id: "reaction-new", content: "🔥" });
+
+    await postModel.createReaction({ targetType: "post", targetId: "post-1", content: "🔥" });
+
+    expect(mocks.ctx.sendActivity.mock.calls[0][2]).toBeInstanceOf(Undo);
+    expect(mocks.prisma.reaction.delete).toHaveBeenCalledWith({ where: { id: "reaction-old" } });
+    expect(mocks.ctx.sendActivity.mock.calls.at(-1)?.[2]).toBeInstanceOf(Like);
   });
 });
 

--- a/src/tests/post.federation.test.ts
+++ b/src/tests/post.federation.test.ts
@@ -296,6 +296,31 @@ describe("post model federation publishing", () => {
     expect(mocks.prisma.reaction.delete).toHaveBeenCalledWith({ where: { id: "reaction-old" } });
     expect(mocks.ctx.sendActivity.mock.calls.at(-1)?.[2]).toBeInstanceOf(Like);
   });
+
+  it("undoes and deletes an existing reaction when cancelling", async () => {
+    mocks.prisma.mainActor.findFirst.mockResolvedValueOnce(localMainActor());
+    mocks.prisma.reaction.findFirst.mockResolvedValueOnce({
+      id: "reaction-1",
+      uri: "https://example.com/activities/reaction-1",
+      content: "🔥",
+      to: ["https://remote.test/users/bob"],
+      cc: ["https://example.com/users/alice/followers"],
+    });
+    mocks.prisma.posts.findUniqueOrThrow.mockResolvedValueOnce({
+      actor: {
+        ...localMainActor().actor,
+        uri: "https://remote.test/users/bob",
+        inboxUrl: "https://remote.test/users/bob/inbox",
+        sharedInboxUrl: "https://remote.test/inbox",
+      },
+    });
+    mocks.prisma.reaction.delete.mockResolvedValueOnce({ id: "reaction-1", content: "🔥" });
+
+    await postModel.deleteReaction({ targetType: "post", targetId: "post-1", content: "🔥" });
+
+    expect(mocks.ctx.sendActivity.mock.calls[0][2]).toBeInstanceOf(Undo);
+    expect(mocks.prisma.reaction.delete).toHaveBeenCalledWith({ where: { id: "reaction-1" } });
+  });
 });
 
 function comment({


### PR DESCRIPTION
## Summary
- Add Reaction persistence for posts/comments and ActivityPub inbox handling for Like/EmojiReact, including custom emoji metadata from FEP-c0e0 tags.
- Add local reaction sending from post/comment UI with a heart-triggered emoji picker; heart sends plain Like and other emoji send Like with content for Mastodon-compatible fallback.
- Replace an existing local reaction by sending Undo, deleting the previous row, then sending the new reaction.

## Related Issues
- Closes #75
- Closes #78

## Tests
- pnpm format
- pnpm lint
- pnpm typecheck
- pnpm test