### PR TITLE
에러/로깅 방식 일관화

### DIFF
--- a/src/components/dashboard/DirectMessageList.tsx
+++ b/src/components/dashboard/DirectMessageList.tsx
@@ -120,7 +120,6 @@ export function DirectMessageList() {
                     최신 3개만 보기
                   </button>
                 )}
-
               </li>
             );
           })}

--- a/src/federation/countFollowers.ts
+++ b/src/federation/countFollowers.ts
@@ -1,5 +1,5 @@
-import { log } from "./log";
 import { prisma } from "~/lib/prisma";
+import { federationLog as log } from "~/lib/server-log";
 
 import type { RequestContext } from "@fedify/fedify";
 

--- a/src/federation/countOutboxItems.ts
+++ b/src/federation/countOutboxItems.ts
@@ -1,5 +1,5 @@
-import { log } from "./log";
 import { prisma } from "~/lib/prisma";
+import { federationLog as log } from "~/lib/server-log";
 
 import type { RequestContext } from "@fedify/fedify";
 

--- a/src/federation/dispatchActor.ts
+++ b/src/federation/dispatchActor.ts
@@ -1,8 +1,8 @@
 import { ActorKeyPair } from "@fedify/fedify";
 import { Endpoints, Image, Person } from "@fedify/vocab";
 
-import { log } from "./log";
 import { prisma } from "~/lib/prisma";
+import { federationLog as log } from "~/lib/server-log";
 
 import type { RequestContext } from "@fedify/fedify";
 

--- a/src/federation/dispatchComment.ts
+++ b/src/federation/dispatchComment.ts
@@ -1,9 +1,9 @@
 import { Document, Mention, Note } from "@fedify/vocab";
 import { Temporal } from "@js-temporal/polyfill";
 
-import { log } from "./log";
 import { createQuoteInteractionPolicy } from "./quoteAuthorization";
 import { prisma } from "~/lib/prisma";
+import { federationLog as log } from "~/lib/server-log";
 
 import type { RequestContext } from "@fedify/fedify";
 

--- a/src/federation/dispatchFollowers.ts
+++ b/src/federation/dispatchFollowers.ts
@@ -1,5 +1,5 @@
-import { log } from "./log";
 import { prisma } from "~/lib/prisma";
+import { federationLog as log } from "~/lib/server-log";
 
 import type { Context } from "@fedify/fedify";
 import type { Recipient } from "@fedify/vocab";

--- a/src/federation/dispatchKeyPairs.ts
+++ b/src/federation/dispatchKeyPairs.ts
@@ -1,8 +1,8 @@
 import { exportJwk, generateCryptoKeyPair, importJwk } from "@fedify/fedify";
 
-import { log } from "./log";
 import { Keys as Key } from "~/generated/prisma";
 import { prisma } from "~/lib/prisma";
+import { federationLog as log } from "~/lib/server-log";
 
 import type { Context } from "@fedify/fedify";
 

--- a/src/federation/dispatchNote.ts
+++ b/src/federation/dispatchNote.ts
@@ -1,6 +1,6 @@
 import { dispatchComment } from "./dispatchComment";
 import { dispatchPost } from "./dispatchPost";
-import { log } from "./log";
+import { federationLog as log } from "~/lib/server-log";
 
 import type { RequestContext } from "@fedify/fedify";
 

--- a/src/federation/dispatchOutbox.ts
+++ b/src/federation/dispatchOutbox.ts
@@ -1,7 +1,7 @@
 import { Create, Note } from "@fedify/vocab";
 
-import { log } from "./log";
 import { prisma } from "~/lib/prisma";
+import { federationLog as log } from "~/lib/server-log";
 
 import type { RequestContext } from "@fedify/fedify";
 

--- a/src/federation/handleCreate.ts
+++ b/src/federation/handleCreate.ts
@@ -1,7 +1,7 @@
 import { isActor, Note } from "@fedify/vocab";
 
-import { log } from "./log";
 import { prisma } from "~/lib/prisma";
+import { federationLog as log } from "~/lib/server-log";
 import {
   formatNoteAttachments,
   getTagFromNote,

--- a/src/federation/handleDelete.ts
+++ b/src/federation/handleDelete.ts
@@ -1,5 +1,5 @@
-import { log } from "./log";
 import { prisma } from "~/lib/prisma";
+import { federationLog as log } from "~/lib/server-log";
 
 import type { InboxActivityStatus } from "./logInboxActivity";
 import type { InboxContext } from "@fedify/fedify";

--- a/src/federation/handleFollow.ts
+++ b/src/federation/handleFollow.ts
@@ -1,7 +1,7 @@
 import { Accept } from "@fedify/vocab";
 
-import { log } from "./log";
 import { prisma } from "~/lib/prisma";
+import { federationLog as log } from "~/lib/server-log";
 import { isUniqueConstraintError, upsertActor } from "~/lib/utils-federation";
 
 import type { InboxActivityStatus } from "./logInboxActivity";

--- a/src/federation/handleQuoteRequest.ts
+++ b/src/federation/handleQuoteRequest.ts
@@ -1,8 +1,8 @@
 import { Accept } from "@fedify/vocab";
 
-import { log } from "./log";
 import { createQuoteAuthorization, getQuoteAuthorizationUri } from "./quoteAuthorization";
 import { prisma } from "~/lib/prisma";
+import { federationLog as log } from "~/lib/server-log";
 
 import type { InboxActivityStatus } from "./logInboxActivity";
 import type { InboxContext } from "@fedify/fedify";

--- a/src/federation/handleReaction.ts
+++ b/src/federation/handleReaction.ts
@@ -1,7 +1,7 @@
 import { Emoji, EmojiReact, isActor, Like } from "@fedify/vocab";
 
-import { log } from "./log";
 import { prisma } from "~/lib/prisma";
+import { federationLog as log } from "~/lib/server-log";
 import { isUniqueConstraintError, upsertActor } from "~/lib/utils-federation";
 
 import type { InboxActivityStatus } from "./logInboxActivity";

--- a/src/federation/handleUndo.ts
+++ b/src/federation/handleUndo.ts
@@ -1,7 +1,7 @@
 import { EmojiReact, Follow, Like } from "@fedify/vocab";
 
-import { log } from "./log";
 import { prisma } from "~/lib/prisma";
+import { federationLog as log } from "~/lib/server-log";
 
 import type { InboxActivityStatus } from "./logInboxActivity";
 import type { InboxContext } from "@fedify/fedify";

--- a/src/federation/handleUpdate.ts
+++ b/src/federation/handleUpdate.ts
@@ -1,7 +1,7 @@
 import { isActor, Note } from "@fedify/vocab";
 
-import { log } from "./log";
 import { prisma } from "~/lib/prisma";
+import { federationLog as log } from "~/lib/server-log";
 import { formatNoteAttachments, getTagFromNote, upsertActor } from "~/lib/utils-federation";
 
 import type { InboxActivityStatus } from "./logInboxActivity";

--- a/src/federation/log.ts
+++ b/src/federation/log.ts
@@ -1,3 +1,0 @@
-import debug from "debug";
-
-export const log = debug("blog:federation");

--- a/src/federation/logInboxActivity.ts
+++ b/src/federation/logInboxActivity.ts
@@ -1,4 +1,5 @@
 import { prisma } from "~/lib/prisma";
+import { federationInboxLog } from "~/lib/server-log";
 
 import type { InboxContext } from "@fedify/fedify";
 import type { Activity } from "@fedify/vocab";
@@ -33,14 +34,23 @@ export function logInboxActivity<TActivity extends Activity>(
         data: { status, handledAt: new Date() },
       });
     } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
       await prisma.inboxActivityLog.update({
         where: { id: logRecord.id },
         data: {
           status: "failed",
-          errorMessage: error instanceof Error ? error.message : String(error),
+          errorMessage,
           handledAt: new Date(),
         },
       });
+      federationInboxLog(
+        "Failed to handle inbox activity: type=%s activityId=%s actor=%s object=%s error=%s",
+        activity.constructor.name,
+        activity.id?.href,
+        activity.actorId?.href,
+        activity.objectId?.href,
+        errorMessage,
+      );
       throw error;
     }
   };

--- a/src/lib/models/post.ts
+++ b/src/lib/models/post.ts
@@ -21,6 +21,7 @@ import { uploadFile } from "./s3";
 import { federation } from "~/federation";
 import { Category, Image, Prisma } from "~/generated/prisma";
 import { prisma } from "~/lib/prisma";
+import { federationDeliveryLog } from "~/lib/server-log";
 
 const commentInclude = {
   attachment: true,
@@ -622,8 +623,8 @@ export async function createComment(
       await ctx.sendActivity({ identifier: username }, directRecipients, create);
     }
   } catch (error) {
-    // Log federation errors but don't fail the comment creation
-    console.error("Failed to send Create activity for comment:", error);
+    // Federation delivery failures should not roll back local comment creation.
+    federationDeliveryLog("Failed to send Create activity for comment: %s", comment.uri, error);
   }
 
   return comment;

--- a/src/lib/models/s3.ts
+++ b/src/lib/models/s3.ts
@@ -1,6 +1,7 @@
 import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import { randomUUID } from "crypto";
 
+import { storageLog } from "../server-log";
 import { convertImageBufferToWebp } from "../utils-image";
 
 if (
@@ -98,7 +99,8 @@ export async function uploadFile(file: File, path: string) {
 
   try {
     await client.send(command);
-  } catch {
+  } catch (error) {
+    storageLog("Failed to upload file to S3 path %s", path, error);
     throw new Error("파일 업로드에 실패했습니다.");
   }
 

--- a/src/lib/server-log.ts
+++ b/src/lib/server-log.ts
@@ -1,0 +1,6 @@
+import debug from "debug";
+
+export const federationLog = debug("blog:federation");
+export const federationInboxLog = debug("blog:federation:inbox");
+export const federationDeliveryLog = debug("blog:federation:delivery");
+export const storageLog = debug("blog:storage");

--- a/src/lib/utils-federation.ts
+++ b/src/lib/utils-federation.ts
@@ -1,15 +1,13 @@
 import { Activity, Document, getActorHandle, Note, PUBLIC_COLLECTION } from "@fedify/vocab";
-import debug from "debug";
 
 import { uploadFile } from "./models/s3";
 import { prisma } from "./prisma";
 import { downloadFile } from "./utils-server";
-
-const log = debug("blog:federation");
+import { federationLog } from "~/lib/server-log";
 
 export async function upsertActor(actor: Awaited<ReturnType<Activity["getActor"]>>) {
   if (!actor || !actor.id || !actor.inboxId) {
-    log("Invalid actor data:", actor);
+    federationLog("Invalid actor data while upserting actor");
     throw new Error("Invalid actor data");
   }
 
@@ -86,7 +84,7 @@ export async function upsertActor(actor: Awaited<ReturnType<Activity["getActor"]
       });
     })
     .catch((err) => {
-      log("Error upserting actor:", err);
+      federationLog("Failed to upsert actor: %s", actorUri, err);
       throw err;
     });
 }

--- a/src/tests/federation.logInboxActivity.test.ts
+++ b/src/tests/federation.logInboxActivity.test.ts
@@ -2,6 +2,14 @@ import { Follow } from "@fedify/vocab";
 
 import { createCtx, mocks } from "./federation.helpers";
 
+const logMocks = vi.hoisted(() => ({
+  federationInboxLog: vi.fn(),
+}));
+
+vi.mock("~/lib/server-log", () => ({
+  federationInboxLog: logMocks.federationInboxLog,
+}));
+
 const { logInboxActivity } = await import("../federation/logInboxActivity");
 
 describe("logInboxActivity", () => {
@@ -50,5 +58,13 @@ describe("logInboxActivity", () => {
       where: { id: "log-1" },
       data: { status: "failed", errorMessage: "boom", handledAt: expect.any(Date) },
     });
+    expect(logMocks.federationInboxLog).toHaveBeenCalledWith(
+      "Failed to handle inbox activity: type=%s activityId=%s actor=%s object=%s error=%s",
+      "Follow",
+      undefined,
+      "https://remote.test/users/bob",
+      "https://example.com/users/alice",
+      "boom",
+    );
   });
 });

--- a/src/tests/post.federation.test.ts
+++ b/src/tests/post.federation.test.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
     lookupObject: vi.fn(),
     sendActivity: vi.fn(),
   },
+  federationDeliveryLog: vi.fn(),
   prisma: {
     $transaction: vi.fn(),
     mainActor: { findFirst: vi.fn() },
@@ -39,6 +40,9 @@ vi.mock("~/federation", () => ({
 }));
 
 vi.mock("~/lib/prisma", () => ({ prisma: mocks.prisma }));
+vi.mock("~/lib/server-log", () => ({
+  federationDeliveryLog: mocks.federationDeliveryLog,
+}));
 vi.mock("../lib/models/s3", () => ({ uploadFile: vi.fn() }));
 vi.mock("../lib/utils-federation", () => ({
   isPublic: (toIds: string[]) => toIds.includes("https://www.w3.org/ns/activitystreams#Public"),
@@ -148,6 +152,34 @@ describe("post model federation publishing", () => {
       { identifier: "alice" },
       "followers",
       expect.anything(),
+    );
+  });
+
+  it("keeps local comment creation when federation Create delivery fails", async () => {
+    mocks.prisma.posts.findUniqueOrThrow.mockResolvedValueOnce({ id: "post-1", slug: "hello" });
+    mocks.prisma.mainActor.findFirst.mockResolvedValueOnce(localMainActor());
+    mocks.prisma.posts.findUnique.mockResolvedValueOnce({
+      actor: { uri: "https://example.com/users/alice", username: "alice" },
+    });
+    mocks.prisma.comment.create.mockResolvedValueOnce({ id: "comment-1" });
+    mocks.prisma.comment.update.mockResolvedValueOnce({
+      id: "comment-1",
+      uri: "https://example.com/post/hello-comment",
+      createdAt: new Date("2026-01-02T00:00:00.000Z"),
+    });
+    mocks.ctx.getObject.mockResolvedValueOnce(null);
+
+    await expect(
+      postModel.createComment("local-actor-id", {
+        postId: "post-1",
+        content: "hello",
+      }),
+    ).resolves.toMatchObject({ id: "comment-1" });
+
+    expect(mocks.federationDeliveryLog).toHaveBeenCalledWith(
+      "Failed to send Create activity for comment: %s",
+      "https://example.com/post/hello-comment",
+      expect.any(Error),
     );
   });
 


### PR DESCRIPTION
## Summary
- Add shared server debug namespaces for federation, federation inbox, federation delivery, and storage logs
- Replace direct federation log module imports with direct imports from the shared server log module
- Replace server-side console.error usage for comment federation delivery failures with debug logging
- Add debug logs for inbox handler failures, actor upsert failures, and S3 upload failures without logging credentials

## Tests
- pnpm format
- pnpm lint
- pnpm typecheck
- pnpm test

Closes #87