### PR TITLE
Add ActivityPub inbox notifications and dashboard summary

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "typecheck": "tsc --noEmit",
     "prisma": "prisma",
     "tunnel": "pnpx untun tunnel http://localhost:3000",
-    "dev:debug": "DEBUG=blog:federation pnpm dev"
+    "dev:debug": "DEBUG=blog:* pnpm dev"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.917.0",

--- a/src/app/dashboard/notifications/page.tsx
+++ b/src/app/dashboard/notifications/page.tsx
@@ -1,0 +1,30 @@
+import { InboxNotificationList } from "~/components/dashboard/InboxNotificationList";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "~/components/ui/card";
+import { DefaultLayout } from "~/layouts/default";
+
+export default function NotificationsPage() {
+  return (
+    <DefaultLayout>
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-2">
+          <h1 className="text-3xl font-bold">ActivityPub 알림</h1>
+          <p className="text-sm text-(--ink-soft)">
+            Inbox history에서 댓글, 마음, 이모지 리액션, 리노트를 모아 보여줍니다.
+          </p>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>알림</CardTitle>
+            <CardDescription>
+              처리 완료된 activity 중 블로그 콘텐츠와 연결된 항목만 표시합니다.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <InboxNotificationList />
+          </CardContent>
+        </Card>
+      </div>
+    </DefaultLayout>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,7 +1,8 @@
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
-import { BugIcon, MailIcon } from "lucide-react";
+import { BellIcon, BugIcon, MailIcon } from "lucide-react";
 import Link from "next/link";
 
+import { ActivityPubOperationSummary } from "~/components/dashboard/ActivityPubOperationSummary";
 import { ManageMainActor } from "~/components/dashboard/ManageMainActor";
 import { ManageUser } from "~/components/dashboard/ManageUser";
 import { PostList } from "~/components/dashboard/post/PostList";
@@ -40,6 +41,11 @@ export default function DashboardPage() {
                     <MailIcon /> 다이렉트 메세지
                   </Button>
                 </Link>
+                <Link href="/dashboard/notifications">
+                  <Button variant="outline">
+                    <BellIcon /> ActivityPub 알림
+                  </Button>
+                </Link>
                 <Link href="/dashboard/activitypub-inbox">
                   <Button variant="outline">
                     <BugIcon /> ActivityPub 수신 로그
@@ -52,6 +58,7 @@ export default function DashboardPage() {
             ActivityPub 다이렉트 메세지를 확인하고, Inbox activity 처리 상태를 추적합니다.
           </CardContent>
         </Card>
+        <ActivityPubOperationSummary />
         <PostList />
         <RecentCommentList />
 

--- a/src/components/dashboard/ActivityPubOperationSummary.tsx
+++ b/src/components/dashboard/ActivityPubOperationSummary.tsx
@@ -1,0 +1,138 @@
+import { format } from "date-fns";
+import Link from "next/link";
+
+import { Badge } from "~/components/ui/badge";
+import { Button } from "~/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
+import { getInboxOperationSummary } from "~/lib/actions/inboxActivityLog";
+
+export async function ActivityPubOperationSummary() {
+  const summary = await getInboxOperationSummary();
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>ActivityPub 운영 상태</CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-5">
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <SummaryMetric label="24시간 수신" value={summary.inboxReceived24h} />
+          <SummaryMetric label="처리 실패" value={summary.failedInboxCount} tone="danger" />
+          <SummaryMetric label="미처리" value={summary.pendingInboxCount} tone="warning" />
+          <SummaryMetric label="팔로워" value={summary.followerCount} />
+        </div>
+
+        <div className="grid gap-4 lg:grid-cols-3">
+          <SummaryList title="최근 팔로우/언팔로우">
+            {summary.recentFollowActivities.length > 0 ? (
+              summary.recentFollowActivities.map((activity) => (
+                <li key={activity.id} className="flex flex-col gap-1">
+                  <div className="flex items-center gap-2">
+                    <Badge variant="outline">{activity.activityType}</Badge>
+                    <span className="text-xs text-(--ink-soft)">{activity.status}</span>
+                  </div>
+                  <span className="truncate text-sm">{activity.actorUri ?? "Actor 없음"}</span>
+                  <time
+                    className="text-xs text-(--ink-soft)"
+                    dateTime={activity.receivedAt.toISOString()}
+                  >
+                    {format(activity.receivedAt, "yyyy.MM.dd HH:mm")}
+                  </time>
+                </li>
+              ))
+            ) : (
+              <EmptyListItem>최근 팔로우/언팔로우가 없습니다.</EmptyListItem>
+            )}
+          </SummaryList>
+
+          <SummaryList title="최근 처리 에러">
+            {summary.recentErrors.length > 0 ? (
+              summary.recentErrors.map((error) => (
+                <li key={error.id} className="flex flex-col gap-1">
+                  <div className="flex items-center gap-2">
+                    <Badge variant="destructive">{error.activityType}</Badge>
+                    <time
+                      className="text-xs text-(--ink-soft)"
+                      dateTime={error.receivedAt.toISOString()}
+                    >
+                      {format(error.receivedAt, "yyyy.MM.dd HH:mm")}
+                    </time>
+                  </div>
+                  <span className="line-clamp-2 text-sm">
+                    {error.errorMessage ?? "에러 메세지 없음"}
+                  </span>
+                  <span className="truncate text-xs text-(--ink-soft)">
+                    {error.actorUri ?? error.objectId ?? "대상 정보 없음"}
+                  </span>
+                </li>
+              ))
+            ) : (
+              <EmptyListItem>최근 처리 에러가 없습니다.</EmptyListItem>
+            )}
+          </SummaryList>
+
+          <SummaryList title="최근 원격 Actor 갱신">
+            {summary.recentActorUpdates.length > 0 ? (
+              summary.recentActorUpdates.map((actor) => (
+                <li key={actor.id} className="flex flex-col gap-1">
+                  <span className="font-medium">{actor.name ?? actor.handle}</span>
+                  <span className="truncate text-sm text-(--ink-soft)">{actor.handle}</span>
+                  <time
+                    className="text-xs text-(--ink-soft)"
+                    dateTime={actor.updatedAt.toISOString()}
+                  >
+                    {format(actor.updatedAt, "yyyy.MM.dd HH:mm")}
+                  </time>
+                </li>
+              ))
+            ) : (
+              <EmptyListItem>최근 갱신된 원격 Actor가 없습니다.</EmptyListItem>
+            )}
+          </SummaryList>
+        </div>
+
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <Link href="/dashboard/notifications">
+            <Button variant="outline">알림 보기</Button>
+          </Link>
+          <Link href="/dashboard/activitypub-inbox">
+            <Button variant="outline">수신 로그 보기</Button>
+          </Link>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function SummaryMetric({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: number;
+  tone?: "danger" | "warning";
+}) {
+  return (
+    <div className="rounded-2xl border border-(--line) bg-(--paper-note) p-4">
+      <div className="text-sm text-(--ink-soft)">{label}</div>
+      <div className={tone === "danger" ? "text-3xl font-bold text-red-700" : "text-3xl font-bold"}>
+        {value.toLocaleString("ko-KR")}
+      </div>
+      {tone === "warning" && <div className="text-xs text-amber-700">처리 지연 여부 확인 필요</div>}
+    </div>
+  );
+}
+
+function SummaryList({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="flex flex-col gap-3 rounded-2xl border border-(--line) p-4">
+      <h2 className="font-bold">{title}</h2>
+      <ul className="flex flex-col gap-3">{children}</ul>
+    </section>
+  );
+}
+
+function EmptyListItem({ children }: { children: React.ReactNode }) {
+  return <li className="text-sm text-(--ink-soft)">{children}</li>;
+}

--- a/src/components/dashboard/InboxNotificationList.tsx
+++ b/src/components/dashboard/InboxNotificationList.tsx
@@ -1,0 +1,52 @@
+import { format } from "date-fns";
+import Link from "next/link";
+
+import { Badge } from "~/components/ui/badge";
+import { getInboxNotificationItems } from "~/lib/actions/inboxActivityLog";
+
+const kindBadgeClassName = {
+  comment: "bg-blue-100 text-blue-800",
+  like: "bg-rose-100 text-rose-800",
+  emoji: "bg-amber-100 text-amber-800",
+  renote: "bg-green-100 text-green-800",
+};
+
+export async function InboxNotificationList() {
+  const items = await getInboxNotificationItems(30);
+
+  if (items.length === 0) {
+    return <p className="text-sm text-(--ink-soft)">표시할 ActivityPub 알림이 없습니다.</p>;
+  }
+
+  return (
+    <ul className="flex flex-col divide-y divide-(--line)">
+      {items.map((item) => (
+        <li key={item.id} className="flex flex-col gap-3 py-4 first:pt-0 last:pb-0">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex flex-wrap items-center gap-2">
+              <Badge className={kindBadgeClassName[item.kind]}>{item.label}</Badge>
+              <span className="font-semibold">{item.actorName}</span>
+              <span className="text-sm text-(--ink-soft)">{item.actorHandle}</span>
+            </div>
+            <time className="text-sm text-(--ink-soft)" dateTime={item.receivedAt.toISOString()}>
+              {format(item.receivedAt, "yyyy.MM.dd HH:mm")}
+            </time>
+          </div>
+
+          <p className="line-clamp-2 text-sm text-(--ink)">{item.content}</p>
+
+          <div className="text-sm text-(--ink-soft)">
+            {item.href ? (
+              <Link href={item.href} className="font-medium text-(--accent-strong) hover:underline">
+                {item.targetTitle}
+              </Link>
+            ) : (
+              <span>{item.targetTitle}</span>
+            )}
+            <span>에 대한 알림</span>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/federation.ts
+++ b/src/federation.ts
@@ -1,6 +1,7 @@
 import { createFederation } from "@fedify/fedify";
 import { RedisKvStore, RedisMessageQueue } from "@fedify/redis";
 import {
+  Announce,
   Create,
   Delete,
   EmojiReact,
@@ -21,6 +22,7 @@ import { dispatchFollowers } from "./federation/dispatchFollowers";
 import { dispatchKeyPairs } from "./federation/dispatchKeyPairs";
 import { dispatchNote } from "./federation/dispatchNote";
 import { dispatchOutbox } from "./federation/dispatchOutbox";
+import { handleAnnounce } from "./federation/handleAnnounce";
 import { handleCreate } from "./federation/handleCreate";
 import { handleDelete } from "./federation/handleDelete";
 import { handleFollow } from "./federation/handleFollow";
@@ -60,6 +62,7 @@ federation
   .on(Update, logInboxActivity(handleUpdate))
   .on(Like, logInboxActivity(handleReaction))
   .on(EmojiReact, logInboxActivity(handleReaction))
+  .on(Announce, logInboxActivity(handleAnnounce))
   .on(QuoteRequest, logInboxActivity(handleQuoteRequest));
 
 federation

--- a/src/federation/handleAnnounce.ts
+++ b/src/federation/handleAnnounce.ts
@@ -1,0 +1,36 @@
+import { isActor } from "@fedify/vocab";
+
+import { prisma } from "~/lib/prisma";
+import { federationLog as log } from "~/lib/server-log";
+import { upsertActor } from "~/lib/utils-federation";
+
+import type { InboxActivityStatus } from "./logInboxActivity";
+import type { InboxContext } from "@fedify/fedify";
+import type { Announce } from "@fedify/vocab";
+
+export async function handleAnnounce(
+  _ctx: InboxContext<unknown>,
+  announce: Announce,
+): Promise<InboxActivityStatus> {
+  log(`Received Announce activity: ${announce.id?.href}`);
+
+  if (announce.actorId == null || announce.objectId == null) return "ignored";
+
+  const actor = await announce.getActor();
+  if (!isActor(actor) || actor.id?.href !== announce.actorId.href) return "ignored";
+
+  const targetUri = announce.objectId.href;
+  const [post, comment] = await Promise.all([
+    prisma.posts.findFirst({ where: { uri: targetUri }, select: { id: true } }),
+    prisma.comment.findFirst({ where: { uri: targetUri }, select: { id: true } }),
+  ]);
+
+  if (!post && !comment) {
+    log(`Announce target not found: ${targetUri}`);
+    return "ignored";
+  }
+
+  await upsertActor(actor);
+
+  return "handled";
+}

--- a/src/lib/actions/inboxActivityLog.ts
+++ b/src/lib/actions/inboxActivityLog.ts
@@ -3,6 +3,48 @@
 import { prisma } from "~/lib/prisma";
 import { getValidAdminSession } from "~/lib/utils-server";
 
+const NOTIFICATION_ACTIVITY_TYPES = ["Create", "Like", "EmojiReact", "Announce"];
+
+export type InboxNotificationItem = {
+  id: string;
+  kind: "comment" | "like" | "emoji" | "renote";
+  label: string;
+  actorName: string;
+  actorHandle: string;
+  content: string;
+  targetTitle: string;
+  href: string | null;
+  receivedAt: Date;
+};
+
+export type InboxOperationSummary = {
+  inboxReceived24h: number;
+  failedInboxCount: number;
+  pendingInboxCount: number;
+  followerCount: number;
+  recentFollowActivities: Array<{
+    id: string;
+    activityType: string;
+    status: string;
+    actorUri: string | null;
+    receivedAt: Date;
+  }>;
+  recentErrors: Array<{
+    id: string;
+    activityType: string;
+    actorUri: string | null;
+    objectId: string | null;
+    errorMessage: string | null;
+    receivedAt: Date;
+  }>;
+  recentActorUpdates: Array<{
+    id: string;
+    name: string | null;
+    handle: string;
+    updatedAt: Date;
+  }>;
+};
+
 export async function getInboxActivityLogs(options?: {
   page?: number;
   limit?: number;
@@ -41,4 +83,218 @@ export async function getInboxActivityLogTypes() {
   });
 
   return records.map((record) => record.activityType);
+}
+
+export async function getInboxOperationSummary(): Promise<InboxOperationSummary> {
+  await getValidAdminSession();
+
+  const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const mainActor = await prisma.mainActor.findFirst({ include: { actor: true } });
+
+  const [
+    inboxReceived24h,
+    failedInboxCount,
+    pendingInboxCount,
+    followerCount,
+    recentFollowActivities,
+    recentErrors,
+    recentActorUpdates,
+  ] = await Promise.all([
+    prisma.inboxActivityLog.count({ where: { receivedAt: { gte: since } } }),
+    prisma.inboxActivityLog.count({ where: { status: "failed" } }),
+    prisma.inboxActivityLog.count({ where: { status: "received" } }),
+    mainActor
+      ? prisma.follows.count({ where: { followingId: mainActor.actorId } })
+      : Promise.resolve(0),
+    prisma.inboxActivityLog.findMany({
+      where: { activityType: { in: ["Follow", "Undo"] } },
+      orderBy: { receivedAt: "desc" },
+      take: 5,
+      select: {
+        id: true,
+        activityType: true,
+        status: true,
+        actorUri: true,
+        receivedAt: true,
+      },
+    }),
+    prisma.inboxActivityLog.findMany({
+      where: { status: "failed" },
+      orderBy: { receivedAt: "desc" },
+      take: 5,
+      select: {
+        id: true,
+        activityType: true,
+        actorUri: true,
+        objectId: true,
+        errorMessage: true,
+        receivedAt: true,
+      },
+    }),
+    prisma.actor.findMany({
+      where: { userId: null },
+      orderBy: { updatedAt: "desc" },
+      take: 5,
+      select: {
+        id: true,
+        name: true,
+        handle: true,
+        updatedAt: true,
+      },
+    }),
+  ]);
+
+  return {
+    inboxReceived24h,
+    failedInboxCount,
+    pendingInboxCount,
+    followerCount,
+    recentFollowActivities,
+    recentErrors,
+    recentActorUpdates,
+  };
+}
+
+export async function getInboxNotificationItems(limit = 20): Promise<InboxNotificationItem[]> {
+  await getValidAdminSession();
+
+  const logs = await prisma.inboxActivityLog.findMany({
+    where: {
+      status: "handled",
+      activityType: { in: NOTIFICATION_ACTIVITY_TYPES },
+    },
+    orderBy: { receivedAt: "desc" },
+    take: limit * 4,
+  });
+
+  const commentUris = logs
+    .filter((log) => log.activityType === "Create" && log.objectId != null)
+    .map((log) => log.objectId!);
+  const reactionUris = logs
+    .filter(
+      (log) =>
+        (log.activityType === "Like" || log.activityType === "EmojiReact") &&
+        log.activityId != null,
+    )
+    .map((log) => log.activityId!);
+  const announcedUris = logs
+    .filter((log) => log.activityType === "Announce" && log.objectId != null)
+    .map((log) => log.objectId!);
+  const actorUris = logs.flatMap((log) => (log.actorUri ? [log.actorUri] : []));
+
+  const [comments, reactions, announcedPosts, announcedComments, actors] = await Promise.all([
+    prisma.comment.findMany({
+      where: { uri: { in: commentUris } },
+      include: {
+        actor: true,
+        post: { select: { title: true, slug: true } },
+      },
+    }),
+    prisma.reaction.findMany({
+      where: { uri: { in: reactionUris } },
+      include: {
+        actor: true,
+        post: { select: { title: true, slug: true } },
+        comment: {
+          select: {
+            url: true,
+            post: { select: { title: true, slug: true } },
+          },
+        },
+      },
+    }),
+    prisma.posts.findMany({
+      where: { uri: { in: announcedUris } },
+      select: { uri: true, title: true, slug: true },
+    }),
+    prisma.comment.findMany({
+      where: { uri: { in: announcedUris } },
+      select: {
+        uri: true,
+        url: true,
+        post: { select: { title: true, slug: true } },
+      },
+    }),
+    prisma.actor.findMany({ where: { uri: { in: actorUris } } }),
+  ]);
+
+  const commentsByUri = new Map(comments.map((comment) => [comment.uri, comment]));
+  const reactionsByUri = new Map(reactions.map((reaction) => [reaction.uri, reaction]));
+  const announcedPostsByUri = new Map(announcedPosts.map((post) => [post.uri, post]));
+  const announcedCommentsByUri = new Map(
+    announcedComments.map((comment) => [comment.uri, comment]),
+  );
+  const actorsByUri = new Map(actors.map((actor) => [actor.uri, actor]));
+  const items: InboxNotificationItem[] = [];
+
+  for (const log of logs) {
+    if (log.activityType === "Create" && log.objectId) {
+      const comment = commentsByUri.get(log.objectId);
+      if (!comment) continue;
+
+      items.push({
+        id: log.id,
+        kind: "comment",
+        label: "댓글",
+        actorName: comment.actor.name ?? comment.actor.username,
+        actorHandle: comment.actor.handle,
+        content: toPlainText(comment.content),
+        targetTitle: comment.post.title,
+        href: comment.url ?? getPostHref(comment.post.slug),
+        receivedAt: log.receivedAt,
+      });
+    }
+
+    if ((log.activityType === "Like" || log.activityType === "EmojiReact") && log.activityId) {
+      const reaction = reactionsByUri.get(log.activityId);
+      if (!reaction) continue;
+
+      const post = reaction.post ?? reaction.comment?.post;
+      if (!post) continue;
+
+      items.push({
+        id: log.id,
+        kind: log.activityType === "Like" ? "like" : "emoji",
+        label: log.activityType === "Like" ? "마음" : "이모지 리액션",
+        actorName: reaction.actor.name ?? reaction.actor.username,
+        actorHandle: reaction.actor.handle,
+        content: reaction.content,
+        targetTitle: post.title,
+        href: reaction.comment?.url ?? getPostHref(post.slug),
+        receivedAt: log.receivedAt,
+      });
+    }
+
+    if (log.activityType === "Announce" && log.objectId) {
+      const actor = log.actorUri ? actorsByUri.get(log.actorUri) : null;
+      const post = announcedPostsByUri.get(log.objectId);
+      const comment = announcedCommentsByUri.get(log.objectId);
+      const targetPost = post ?? comment?.post;
+      if (!targetPost) continue;
+
+      items.push({
+        id: log.id,
+        kind: "renote",
+        label: "리노트",
+        actorName: actor?.name ?? actor?.username ?? log.actorUri ?? "알 수 없는 actor",
+        actorHandle: actor?.handle ?? log.actorUri ?? "-",
+        content: "리노트했습니다.",
+        targetTitle: targetPost.title,
+        href: comment?.url ?? getPostHref(targetPost.slug),
+        receivedAt: log.receivedAt,
+      });
+    }
+
+    if (items.length >= limit) break;
+  }
+
+  return items;
+}
+
+function getPostHref(slug: string | null) {
+  return slug ? `/post/${slug}` : null;
+}
+
+function toPlainText(content: string) {
+  return content.replace(/<[^>]*>/g, "").trim() || "내용 없음";
 }

--- a/src/tests/federation.handleAnnounce.test.ts
+++ b/src/tests/federation.handleAnnounce.test.ts
@@ -1,0 +1,42 @@
+import { Announce } from "@fedify/vocab";
+
+import { createCtx, createRemoteActor, mocks } from "./federation.helpers";
+
+const { handleAnnounce } = await import("../federation/handleAnnounce");
+
+describe("handleAnnounce", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("handles a remote Announce for a local post", async () => {
+    const actor = createRemoteActor();
+    const announce = new Announce({
+      id: new URL("https://remote.test/activities/announce-1"),
+      actor: actor.id,
+      object: new URL("https://example.com/post/hello"),
+    });
+    vi.spyOn(announce, "getActor").mockResolvedValue(actor);
+    mocks.prisma.posts.findFirst.mockResolvedValueOnce({ id: "post-1" });
+    mocks.prisma.comment.findFirst.mockResolvedValueOnce(null);
+    mocks.upsertActor.mockResolvedValueOnce({ id: "remote-actor" });
+
+    await expect(handleAnnounce(createCtx(), announce)).resolves.toBe("handled");
+
+    expect(mocks.upsertActor).toHaveBeenCalledWith(actor);
+  });
+
+  it("ignores an Announce when the target is not local", async () => {
+    const actor = createRemoteActor();
+    const announce = new Announce({
+      id: new URL("https://remote.test/activities/announce-1"),
+      actor: actor.id,
+      object: new URL("https://remote.test/notes/1"),
+    });
+    vi.spyOn(announce, "getActor").mockResolvedValue(actor);
+    mocks.prisma.posts.findFirst.mockResolvedValueOnce(null);
+    mocks.prisma.comment.findFirst.mockResolvedValueOnce(null);
+
+    await expect(handleAnnounce(createCtx(), announce)).resolves.toBe("ignored");
+
+    expect(mocks.upsertActor).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/federation.helpers.ts
+++ b/src/tests/federation.helpers.ts
@@ -6,7 +6,7 @@ vi.hoisted(() => {
   const global = globalThis as typeof globalThis & { __federationTestMocks?: FederationTestMocks };
   global.__federationTestMocks = {
     prisma: {
-      actor: { findFirst: vi.fn() },
+      actor: { findFirst: vi.fn(), findMany: vi.fn() },
       keys: { upsert: vi.fn() },
       follows: { create: vi.fn(), deleteMany: vi.fn(), findMany: vi.fn(), count: vi.fn() },
       inboxActivityLog: { create: vi.fn(), update: vi.fn(), findMany: vi.fn(), count: vi.fn() },
@@ -23,7 +23,7 @@ vi.hoisted(() => {
 
 type FederationTestMocks = {
   prisma: {
-    actor: { findFirst: ReturnType<typeof vi.fn> };
+    actor: { findFirst: ReturnType<typeof vi.fn>; findMany: ReturnType<typeof vi.fn> };
     keys: { upsert: ReturnType<typeof vi.fn> };
     follows: {
       create: ReturnType<typeof vi.fn>;


### PR DESCRIPTION
## Summary
- add an Announce inbox listener and handler so renotes are recorded in inbox history
- add an ActivityPub notifications dashboard for comments, likes, emoji reactions, and renotes
- add an ActivityPub operation summary to the admin dashboard with inbox counts, followers, recent follow activity, recent errors, and remote actor updates

## Notes
- Uses existing `InboxActivityLog` and domain tables instead of adding a new notification table.
- Outbound federation delivery failures are still only available through debug logging and are not persisted in this PR.

## Verification
- `pnpm format`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`

Refs #57
Refs #85