### PR TITLE
Use Next standalone Docker output

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  output: "standalone",
   webpack(config) {
     config.resolve.alias = {
       ...config.resolve.alias,

--- a/prod.Dockerfile
+++ b/prod.Dockerfile
@@ -1,14 +1,26 @@
-FROM node:22-alpine
+FROM node:22-alpine AS builder
 
 WORKDIR /app
 
-RUN npm install -g pnpm
+RUN corepack enable
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
-ADD public public
 RUN pnpm install --frozen-lockfile
 
 COPY . .
 
+RUN pnpm prisma generate
 RUN pnpm build
-CMD ["pnpm", "start"]
+
+FROM node:22-alpine AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV HOSTNAME=0.0.0.0
+
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+
+CMD ["node", "server.js"]


### PR DESCRIPTION
Summary:
- Enable Next.js standalone output in next.config.ts.
- Convert prod.Dockerfile to a builder/runner production image using Corepack pnpm.
- Copy .next/standalone, .next/static, and public separately, and start with node server.js.

Tests:
- pnpm format: pass
- pnpm lint: pass
- pnpm typecheck: pass after local pnpm prisma generate because src/generated/prisma is ignored
- pnpm test: pass
- docker build -f prod.Dockerfile .: fail because S3_PUBLIC_URL is unset, so existing next.config.ts image remotePatterns throws ERR_INVALID_URL while loading config

Closes #96