### PR TITLE
Centralize comment visibility policy

### DIFF
--- a/src/lib/actions/post.ts
+++ b/src/lib/actions/post.ts
@@ -74,9 +74,9 @@ export async function getCommentsBySlug(slug: string) {
 }
 
 export async function getRecentComments(limit?: number) {
-  await getValidAdminSession();
+  const session = await getValidAdminSession();
 
-  const postService = new PostService();
+  const postService = new PostService(session.user.id, session.user.role === "admin");
 
   return await postService.getRecentComments(limit);
 }

--- a/src/lib/models/post.ts
+++ b/src/lib/models/post.ts
@@ -16,12 +16,14 @@ import { Temporal } from "@js-temporal/polyfill";
 import DOMPurify from "isomorphic-dompurify";
 import { marked } from "marked";
 
-import { isFollowersOnly, isNonList, isPublic } from "../utils-federation";
+import { canViewComment, isFollowersOnly, isNonList, isPublic } from "../utils-federation";
 import { uploadFile } from "./s3";
 import { federation } from "~/federation";
 import { Category, Image, Prisma } from "~/generated/prisma";
 import { prisma } from "~/lib/prisma";
 import { federationDeliveryLog } from "~/lib/server-log";
+
+import type { CommentVisibilityViewer } from "../utils-federation";
 
 const commentInclude = {
   attachment: true,
@@ -341,7 +343,7 @@ export async function getCategories() {
 
 export async function getCommentsBySlug(
   slug: string,
-  options: { includeFollowersOnly?: boolean } = {},
+  options: { viewer?: CommentVisibilityViewer } = {},
 ) {
   const { id: postId } = await prisma.posts.findUniqueOrThrow({
     where: { slug },
@@ -357,9 +359,7 @@ export async function getCommentsBySlug(
   const commentsById = new Map<string, CommentWithReplies>();
   const topLevelComments: CommentWithReplies[] = [];
 
-  const visibleComments = options.includeFollowersOnly
-    ? comments
-    : comments.filter((comment) => !isFollowersOnly(comment.to, comment.cc));
+  const visibleComments = comments.filter((comment) => canViewComment(comment, options.viewer));
 
   for (const comment of visibleComments) {
     commentsById.set(comment.id, { ...comment, replies: [] });
@@ -378,10 +378,13 @@ export async function getCommentsBySlug(
   return topLevelComments;
 }
 
-export async function getRecentComments(limit = 5) {
-  return await prisma.comment.findMany({
+export async function getRecentComments(
+  limit = 5,
+  options: { viewer?: CommentVisibilityViewer } = {},
+) {
+  const comments = await prisma.comment.findMany({
     orderBy: { createdAt: "desc" },
-    take: limit,
+    take: options.viewer?.role === "admin" ? limit : undefined,
     include: {
       actor: true,
       post: {
@@ -392,6 +395,8 @@ export async function getRecentComments(limit = 5) {
       },
     },
   });
+
+  return comments.filter((comment) => canViewComment(comment, options.viewer)).slice(0, limit);
 }
 
 export async function createComment(

--- a/src/lib/services/post.ts
+++ b/src/lib/services/post.ts
@@ -81,11 +81,15 @@ export class PostService {
   }
 
   async getCommentsBySlug(slug: string) {
-    return await getCommentsBySlug(slug, { includeFollowersOnly: this.isAdmin });
+    return await getCommentsBySlug(slug, {
+      viewer: this.isAdmin ? { role: "admin" } : undefined,
+    });
   }
 
   async getRecentComments(limit?: number) {
-    return await getRecentComments(limit);
+    return await getRecentComments(limit, {
+      viewer: this.isAdmin ? { role: "admin" } : undefined,
+    });
   }
 
   @requireUserId

--- a/src/lib/utils-federation.ts
+++ b/src/lib/utils-federation.ts
@@ -123,6 +123,21 @@ export function isFollowersOnly(toIds: URL[] | string[], ccIds: URL[] | string[]
   return false;
 }
 
+export type CommentVisibilityViewer = { role?: "admin" | string } | null | undefined;
+
+export type CommentVisibilityInput = {
+  to: URL[] | string[];
+  cc: URL[] | string[];
+};
+
+export function canViewComment(comment: CommentVisibilityInput, viewer?: CommentVisibilityViewer) {
+  if (viewer?.role === "admin") {
+    return true;
+  }
+
+  return isPublic(comment.to) === true || isNonList(comment.to, comment.cc);
+}
+
 export function getTagFromNote(note: Note) {
   const json = note.toJsonLd() as
     | {

--- a/src/tests/post.federation.test.ts
+++ b/src/tests/post.federation.test.ts
@@ -46,9 +46,16 @@ vi.mock("~/lib/server-log", () => ({
 vi.mock("../lib/models/s3", () => ({ uploadFile: vi.fn() }));
 vi.mock("../lib/utils-federation", () => ({
   isPublic: (toIds: string[]) => toIds.includes("https://www.w3.org/ns/activitystreams#Public"),
-  isNonList: () => false,
+  isNonList: (toIds: string[], ccIds: string[]) =>
+    toIds.some((id) => id !== "https://www.w3.org/ns/activitystreams#Public") &&
+    ccIds.includes("https://www.w3.org/ns/activitystreams#Public"),
   isFollowersOnly: (toIds: string[], ccIds: string[]) =>
     ![...toIds, ...ccIds].includes("https://www.w3.org/ns/activitystreams#Public"),
+  canViewComment: (comment: { to: string[]; cc: string[] }, viewer?: { role?: string } | null) =>
+    viewer?.role === "admin" ||
+    comment.to.includes("https://www.w3.org/ns/activitystreams#Public") ||
+    (comment.to.some((id) => id !== "https://www.w3.org/ns/activitystreams#Public") &&
+      comment.cc.includes("https://www.w3.org/ns/activitystreams#Public")),
 }));
 vi.mock("marked", () => ({ marked: vi.fn(async (content: string) => `<p>${content}</p>`) }));
 vi.mock("isomorphic-dompurify", () => ({
@@ -249,19 +256,99 @@ describe("post model federation publishing", () => {
     expect(comments.map((comment) => comment.id)).toEqual(["comment-1"]);
   });
 
-  it("returns followers-only comments to admin readers", async () => {
+  it("returns public and unlisted comments to anonymous readers", async () => {
+    const publicComment = comment({ id: "comment-1", parentId: null });
+    const unlistedComment = comment({
+      id: "comment-2",
+      parentId: null,
+      to: ["https://example.com/users/alice/followers"],
+      cc: ["https://www.w3.org/ns/activitystreams#Public"],
+    });
+
+    mocks.prisma.posts.findUniqueOrThrow.mockResolvedValueOnce({ id: "post-1" });
+    mocks.prisma.comment.findMany.mockResolvedValueOnce([publicComment, unlistedComment]);
+
+    const comments = await postModel.getCommentsBySlug("hello");
+
+    expect(comments.map((comment) => comment.id)).toEqual(["comment-1", "comment-2"]);
+  });
+
+  it("hides direct comments from anonymous readers", async () => {
+    const directComment = comment({
+      id: "comment-1",
+      parentId: null,
+      to: ["https://remote.test/users/bob"],
+    });
+
+    mocks.prisma.posts.findUniqueOrThrow.mockResolvedValueOnce({ id: "post-1" });
+    mocks.prisma.comment.findMany.mockResolvedValueOnce([directComment]);
+
+    const comments = await postModel.getCommentsBySlug("hello");
+
+    expect(comments).toEqual([]);
+  });
+
+  it("returns followers-only and direct comments to admin readers", async () => {
     const followersOnlyComment = comment({
       id: "comment-1",
       parentId: null,
       to: ["https://example.com/users/alice/followers"],
     });
+    const directComment = comment({
+      id: "comment-2",
+      parentId: null,
+      to: ["https://remote.test/users/bob"],
+    });
 
     mocks.prisma.posts.findUniqueOrThrow.mockResolvedValueOnce({ id: "post-1" });
-    mocks.prisma.comment.findMany.mockResolvedValueOnce([followersOnlyComment]);
+    mocks.prisma.comment.findMany.mockResolvedValueOnce([followersOnlyComment, directComment]);
 
-    const comments = await postModel.getCommentsBySlug("hello", { includeFollowersOnly: true });
+    const comments = await postModel.getCommentsBySlug("hello", { viewer: { role: "admin" } });
+
+    expect(comments.map((comment) => comment.id)).toEqual(["comment-1", "comment-2"]);
+  });
+
+  it("filters recent comments with the shared visibility policy", async () => {
+    const publicComment = comment({ id: "comment-1", parentId: null });
+    const directComment = comment({
+      id: "comment-2",
+      parentId: null,
+      to: ["https://remote.test/users/bob"],
+    });
+    const unlistedComment = comment({
+      id: "comment-3",
+      parentId: null,
+      to: ["https://example.com/users/alice/followers"],
+      cc: ["https://www.w3.org/ns/activitystreams#Public"],
+    });
+    mocks.prisma.comment.findMany.mockResolvedValueOnce([
+      directComment,
+      publicComment,
+      unlistedComment,
+    ]);
+
+    const comments = await postModel.getRecentComments(2);
+
+    expect(comments.map((comment) => comment.id)).toEqual(["comment-1", "comment-3"]);
+    expect(mocks.prisma.comment.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: undefined }),
+    );
+  });
+
+  it("returns admin-visible recent comments", async () => {
+    const directComment = comment({
+      id: "comment-1",
+      parentId: null,
+      to: ["https://remote.test/users/bob"],
+    });
+    mocks.prisma.comment.findMany.mockResolvedValueOnce([directComment]);
+
+    const comments = await postModel.getRecentComments(5, { viewer: { role: "admin" } });
 
     expect(comments.map((comment) => comment.id)).toEqual(["comment-1"]);
+    expect(mocks.prisma.comment.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 5 }),
+    );
   });
 
   it("sends a heart reaction as Like", async () => {

--- a/src/tests/utils-federation.test.ts
+++ b/src/tests/utils-federation.test.ts
@@ -5,6 +5,7 @@ vi.mock("../lib/prisma", () => ({ prisma: {} }));
 vi.mock("../lib/utils-server", () => ({ downloadFile: vi.fn() }));
 
 import {
+  canViewComment,
   getTagFromNote,
   isFollowersOnly,
   isNonList,
@@ -30,6 +31,40 @@ describe("utils-federation", () => {
     it("detects followers-only addressing", () => {
       expect(isFollowersOnly(["https://example.com/users/alice/followers"], [])).toBe(true);
       expect(isFollowersOnly([], [PUBLIC_COLLECTION.href])).toBe(false);
+    });
+
+    it("allows public comments for anonymous readers and admin", () => {
+      const comment = { to: [PUBLIC_COLLECTION.href], cc: [] };
+
+      expect(canViewComment(comment)).toBe(true);
+      expect(canViewComment(comment, { role: "user" })).toBe(true);
+      expect(canViewComment(comment, { role: "admin" })).toBe(true);
+    });
+
+    it("allows unlisted comments for anonymous readers and admin", () => {
+      const comment = {
+        to: ["https://example.com/users/alice/followers"],
+        cc: [PUBLIC_COLLECTION.href],
+      };
+
+      expect(canViewComment(comment)).toBe(true);
+      expect(canViewComment(comment, { role: "user" })).toBe(true);
+      expect(canViewComment(comment, { role: "admin" })).toBe(true);
+    });
+
+    it("hides followers-only comments from anonymous and ordinary readers", () => {
+      const comment = { to: ["https://example.com/users/alice/followers"], cc: [] };
+
+      expect(canViewComment(comment)).toBe(false);
+      expect(canViewComment(comment, { role: "user" })).toBe(false);
+      expect(canViewComment(comment, { role: "admin" })).toBe(true);
+    });
+
+    it("hides direct comments from anonymous readers and allows admin", () => {
+      const comment = { to: ["https://remote.test/users/bob"], cc: [] };
+
+      expect(canViewComment(comment)).toBe(false);
+      expect(canViewComment(comment, { role: "admin" })).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary
- Add shared canViewComment policy for public, unlisted, followers-only, and direct comment visibility.
- Use the shared policy in slug comment lists and recent comments with admin viewer context from server actions/services.
- Add coverage for anonymous, ordinary, and admin visibility cases.

## Tests
- pnpm test -- src/tests/utils-federation.test.ts src/tests/post.federation.test.ts
- pnpm format
- pnpm lint
- pnpm typecheck
- pnpm test

Closes #86